### PR TITLE
Refactor Campaigner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ resolvers += "ATS Snapshots" at "http://nexus.prod01.internal.advancedtelematic.
 libraryDependencies ++= {
   val akkaHttpV = "10.0.3"
   val akkaV = "2.4.17"
-  val libatsV = "0.0.1-63-g8dcff8c"
+  val libatsV = "0.0.1-77-g30137be"
   val scalaTestV = "3.0.0"
   val slickV = "3.2.0"
 
@@ -59,13 +59,6 @@ enablePlugins(BuildInfoPlugin)
 buildInfoOptions += BuildInfoOption.ToMap
 
 buildInfoOptions += BuildInfoOption.BuildTime
-
-
-flywayUrl := sys.env.getOrElse("DB_URL", "jdbc:mysql://localhost:3306/campaigner")
-
-flywayUser := sys.env.getOrElse("DB_USER", "campaigner")
-
-flywayPassword := sys.env.getOrElse("DB_PASSWORD", "campaigner")
 
 mainClass in Compile := Some("com.advancedtelematic.campaigner.Boot")
 

--- a/project/Versioning.scala
+++ b/project/Versioning.scala
@@ -1,25 +1,17 @@
 import com.typesafe.sbt.SbtGit._
 import com.typesafe.sbt.SbtGit.GitKeys._
 import com.typesafe.sbt.GitVersioning
+import com.typesafe.sbt.git.ConsoleGitRunner
+
 import scala.util.Try
 import sbt._
 import sbt.Keys._
 
 object Versioning {
-  /**
-    * Currently there is a problem with JGit where it returns a wrong
-    * git describe version, so we use git directly
-    */
-  lazy val consoleGitDescribe = Try("git describe".!!).toOption.map(_.trim)
-
   lazy val settings = Seq(
+    git.runner := ConsoleGitRunner,
     git.useGitDescribe := true,
-    git.baseVersion := "0.0.1",
-    git.gitDescribedVersion := consoleGitDescribe
-      orElse gitReader.value.withGit(_.describedVersion)
-      map(_.drop(1))
-      orElse formattedShaVersion.value
-      orElse Some(git.baseVersion.value)
+    git.baseVersion := "0.0.1"
   )
 
   val Plugin = GitVersioning

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,5 @@
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 
-addSbtPlugin("org.flywaydb" % "flyway-sbt" % "4.0.3")
-
-resolvers += "Flyway" at "https://flywaydb.org/repo"
-
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.4")

--- a/src/main/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateReportListener.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateReportListener.scala
@@ -2,18 +2,18 @@ package com.advancedtelematic.campaigner.daemon
 
 import akka.actor.{ActorSystem, Props}
 import com.advancedtelematic.campaigner.data.DataType._
-import com.advancedtelematic.campaigner.db.CampaignSupport
+import com.advancedtelematic.campaigner.db.Campaigns
 import com.advancedtelematic.libats.messaging.MessageListener
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceUpdateReport
 import com.typesafe.config.Config
+
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
 
-object DeviceUpdateReportListener extends CampaignSupport {
-
-  def handler(msg: DeviceUpdateReport)
-    (implicit db: Database, ec: ExecutionContext): Future[Unit] =
-    Campaigns.finishDevice(
+object DeviceUpdateReportListener {
+  def apply(msg: DeviceUpdateReport)
+           (implicit db: Database, ec: ExecutionContext): Future[Unit] =
+    Campaigns().finishDevice(
       msg.updateId,
       msg.device,
       if (msg.operationResult.values.forall(_.isSuccess))
@@ -24,6 +24,5 @@ object DeviceUpdateReportListener extends CampaignSupport {
 
   def props(config: Config)
       (implicit db:Database, ec: ExecutionContext, system: ActorSystem): Props  =
-    MessageListener.props[DeviceUpdateReport](config, handler)
-
+    MessageListener.props[DeviceUpdateReport](config, apply)
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
@@ -2,15 +2,11 @@ package com.advancedtelematic.campaigner.data
 
 import com.advancedtelematic.libats.codecs.AkkaCirce._
 import com.advancedtelematic.libats.codecs.Codecs._
-import com.advancedtelematic.libats.data.UUIDKey.UUIDKey
-import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
-import java.util.UUID
+import io.circe.{Decoder, Encoder}
 
 object Codecs {
-
   import DataType._
   import io.circe.generic.semiauto._
-  import shapeless._
 
   implicit val decoderCampaign: Decoder[Campaign] = deriveDecoder
   implicit val encoderCampaign: Encoder[Campaign] = deriveEncoder
@@ -27,13 +23,6 @@ object Codecs {
   implicit val decoderStats: Decoder[Stats] = deriveDecoder
   implicit val encoderStats: Encoder[Stats] = deriveEncoder
 
-  implicit def uuidKeyDecoder[T](implicit gen: Generic.Aux[T, UUID :: HNil]): KeyDecoder[T] =
-    KeyDecoder[String].map(s => gen.from(UUID.fromString(s) :: HNil))
-
-  implicit def uuidKeyEncoder[T <: UUIDKey]: KeyEncoder[T] =
-    KeyEncoder[String].contramap(_.uuid.toString)
-
   implicit val decoderCampaignStats: Decoder[CampaignStats] = deriveDecoder
   implicit val encoderCampaignStats: Encoder[CampaignStats] = deriveEncoder
-
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -8,6 +8,10 @@ import com.advancedtelematic.libats.slick.codecs.SlickEnum
 import java.time.Instant
 import java.util.UUID
 
+import com.advancedtelematic.campaigner.data.DataType.CampaignStatus.CampaignStatus
+import com.advancedtelematic.campaigner.data.DataType.DeviceStatus.DeviceStatus
+import com.advancedtelematic.campaigner.data.DataType.GroupStatus.GroupStatus
+
 object DataType {
 
   final case class CampaignId(uuid: UUID) extends UUIDKey
@@ -71,28 +75,31 @@ object DataType {
   final case class Stats(processed: Long, affected: Long)
 
   object GroupStatus extends CirceEnum with SlickEnum {
+    type GroupStatus = Value
     val scheduled, launched, cancelled = Value
   }
 
   object CampaignStatus extends CirceEnum {
+    type CampaignStatus = Value
     val prepared, scheduled, launched, finished, cancelled = Value
   }
 
   object DeviceStatus extends Enumeration with SlickEnum {
+    type DeviceStatus = Value
     val scheduled, successful, cancelled, failed = Value
   }
 
   final case class GroupStats(
     campaign: CampaignId,
     group: GroupId,
-    status: GroupStatus.Value,
+    status: GroupStatus,
     processed: Long,
     affected: Long
   )
 
   final case class CampaignStats(
     campaign: CampaignId,
-    status: CampaignStatus.Value,
+    status: CampaignStatus,
     finished: Long,
     failed: Set[DeviceId],
     stats: Map[GroupId, Stats]
@@ -102,7 +109,6 @@ object DataType {
     campaign: CampaignId,
     update: UpdateId,
     device: DeviceId,
-    status: DeviceStatus.Value
+    status: DeviceStatus
   )
-
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -1,46 +1,128 @@
 package com.advancedtelematic.campaigner.db
 
+import com.advancedtelematic.campaigner.data.DataType.CampaignStatus.CampaignStatus
+import com.advancedtelematic.campaigner.data.DataType.DeviceStatus.DeviceStatus
+import com.advancedtelematic.campaigner.data.DataType.GroupStatus.GroupStatus
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.http.Errors
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
+import slick.jdbc.MySQLProfile.api._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
-import scala.concurrent.{ExecutionContext, Future}
-import slick.jdbc.MySQLProfile.api._
 
-trait CampaignSupport {
-  def Campaigns(implicit db: Database, ec: ExecutionContext) = new Campaigns()
+import scala.concurrent.{ExecutionContext, Future}
+
+object Campaigns {
+  def apply()(implicit db: Database, ec: ExecutionContext): Campaigns = new Campaigns()
 }
 
-protected class Campaigns()(implicit db: Database, ec: ExecutionContext) {
+protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
+  extends GroupStatsSupport
+    with CampaignSupport
+    with DeviceUpdateSupport {
 
-  import com.advancedtelematic.libats.slick.db.SlickAnyVal._
+  def remainingCampaigns(): Future[Seq[Campaign]] = campaignRepo.findAllScheduled()
 
-  def persist(campaign: Campaign, groups: Set[GroupId]): Future[Unit] =
-    db.run {
-      val f = for {
-        _ <- Schema.campaigns += campaign
-        _ <- Schema.campaignGroups ++= groups.map(g => (campaign.id, g))
-      } yield ()
+  def remainingGroups(campaign: CampaignId): Future[Seq[GroupId]] =
+    groupStatsRepo.findScheduled(campaign).map(_.map(_.group))
 
-      f.transactionally
-        .handleIntegrityErrors(Errors.ConflictingCampaign)
+  def remainingBatches(campaign: CampaignId, group: GroupId): Future[Option[Long]] =
+    groupStatsRepo.findScheduled(campaign, Some(group))
+      .map(_.headOption)
+      .map(_.map(_.processed))
+
+  def completeBatch(
+                     ns: Namespace,
+                     campaign: CampaignId,
+                     group: GroupId,
+                     stats: Stats): Future[Unit] =
+    progressGroup(ns, campaign, group, GroupStatus.scheduled, stats)
+
+  def completeGroup(
+                     ns: Namespace,
+                     campaign: CampaignId,
+                     group: GroupId,
+                     stats: Stats): Future[Unit] =
+    progressGroup(ns, campaign, group, GroupStatus.launched, stats)
+
+  def cancelCampaign(
+                      ns: Namespace,
+                      campaign: CampaignId) : Future[Unit] =
+    campaignRepo.find(ns, campaign).flatMap { _ =>
+      groupStatsRepo.cancel(campaign)
     }
 
-  private[db] def find(ns: Namespace, campaign: CampaignId): DBIO[Campaign] =
-    Schema.campaigns
-      .filter(_.namespace === ns)
-      .filter(_.id === campaign)
-      .result
-      .failIfNotSingle(Errors.CampaignMissing)
+  def failedDevices(ns: Namespace, campaign: CampaignId): Future[Set[DeviceId]] = db.run {
+    campaignRepo.findAction(ns, campaign).flatMap { _ =>
+      deviceUpdateRepo.findByCampaignAction(campaign, DeviceStatus.failed)
+    }
+  }
 
-  def findCampaign(ns: Namespace, campaign: CampaignId): Future[Campaign] =
-    db.run(find(ns, campaign))
+  def freshCampaigns(): Future[Seq[Campaign]] =
+    campaignRepo.findAllScheduled { groupStats =>
+      groupStats.processed === 0L && groupStats.affected === 0L
+    }
 
-  def findGroups(ns: Namespace, campaign: CampaignId): Future[Set[GroupId]] =
+  def scheduleDevice(campaign: CampaignId, update: UpdateId, device: DeviceId): Future[Unit] =
+    deviceUpdateRepo.persist(DeviceUpdate(campaign, update, device, DeviceStatus.scheduled))
+
+  def finishDevice(update: UpdateId, device: DeviceId, status: DeviceStatus): Future[Unit] =
+    deviceUpdateRepo.setUpdateStatus(update, device, status)
+
+  def countFinished(ns: Namespace, campaignId: CampaignId): Future[Long] =
+    campaignRepo.countFinished(ns, campaignId)
+
+  def findCampaign(ns: Namespace, campaignId: CampaignId): Future[GetCampaign] = for {
+    c <- campaignRepo.findCampaign(ns, campaignId)
+    groups <- findGroups(ns, c.id)
+  } yield GetCampaign(c, groups)
+
+  def status(campaign: CampaignId): Future[CampaignStatus] =
+    groupStatsRepo.aggregatedStatus(campaign)
+
+  def campaignStats(ns: Namespace, campaign: CampaignId): Future[CampaignStats] = for {
+    status   <- status(campaign)
+    finished <- countFinished(ns, campaign)
+    failed   <- failedDevices(ns, campaign)
+    stats    <- campaignStatsFor(ns, campaign)
+  } yield CampaignStats(campaign, status, finished, failed, stats)
+
+  def launch(ns: Namespace, id: CampaignId): Future[Unit] = for {
+    groups <- findGroups(ns, id)
+    _ <- scheduleGroups(ns, id, groups)
+  } yield ()
+
+  def create(campaign: Campaign, groups: Set[GroupId]): Future[CampaignId] =
+    campaignRepo.persist(campaign, groups)
+
+  def update(ns: Namespace, id: CampaignId, name: String): Future[Unit] =
+    campaignRepo.updateName(ns, id, name)
+
+  def scheduleGroups(ns: Namespace, campaign: CampaignId, groups: Set[GroupId]): Future[Unit] =
     db.run {
-      find(ns, campaign).flatMap { _ =>
+      campaignRepo
+        .findAction(ns, campaign)
+        .andThen(groupStatsRepo.persistManyAction(campaign, groups))
+        .transactionally
+        .handleIntegrityErrors(Errors.CampaignAlreadyLaunched)
+    }
+
+  def campaignStatsFor(ns: Namespace, campaign: CampaignId): Future[Map[GroupId, Stats]] =
+    db.run {
+      campaignRepo.findAction(ns, campaign).flatMap { _ =>
+        groupStatsRepo.findByCampaignAction(campaign)
+      }
+    }.map {
+      _.groupBy(_.group).map {
+        case (group, stats +: _) => (group, Stats(stats.processed, stats.affected))
+      }
+    }
+
+  // TODO: I think this can go, see schema.scala
+  private def findGroups(ns: Namespace, campaign: CampaignId): Future[Set[GroupId]] =
+    db.run {
+      campaignRepo.findAction(ns, campaign).flatMap { _ =>
         Schema.campaignGroups
           .filter(_.campaignId === campaign)
           .map(_.groupId)
@@ -49,211 +131,13 @@ protected class Campaigns()(implicit db: Database, ec: ExecutionContext) {
       }
     }
 
-  def update(ns: Namespace, campaign: CampaignId, name: String): Future[Unit] =
-    db.run {
-      find(ns, campaign).flatMap { _ =>
-        Schema.campaigns
-          .filter(_.id === campaign)
-          .map(_.name)
-          .update(name)
-          .map(_ => ())
-          .handleIntegrityErrors(Errors.ConflictingCampaign)
-      }
-    }
-
-  def scheduleGroups(ns: Namespace, campaign: CampaignId, groups: Set[GroupId]): Future[Unit] =
-    db.run {
-      val f = for {
-        _ <- find(ns, campaign)
-        _ <- DBIO.sequence(groups.toSeq.map { group =>
-          Schema.groupStats += GroupStats(campaign, group, GroupStatus.scheduled, 0, 0)
-        })
-      } yield ()
-
-      f.transactionally
-        .handleIntegrityErrors(Errors.CampaignAlreadyLaunched)
-    }
-
-  def aggregatedStatus(campaign: CampaignId): Future[CampaignStatus.Value] = {
-    def groupStats(status: GroupStatus.Value) =
-      Schema.groupStats
-        .filter(_.campaignId === campaign)
-        .filter(_.status === status)
-        .length.result
-
-    db.run {
-      for {
-        scheduled <- groupStats(GroupStatus.scheduled)
-        launched  <- groupStats(GroupStatus.launched)
-        cancelled <- groupStats(GroupStatus.cancelled)
-        status     = (scheduled, launched, cancelled) match {
-          case (_, _, c) if c > 0 => CampaignStatus.cancelled
-          case (0, l, _) if l > 0 => CampaignStatus.launched
-          case (0, 0, _)          => CampaignStatus.prepared
-          case _                  => CampaignStatus.scheduled
-        }
-      } yield status
-    }
-  }
-
-  def groupStatusFor(campaign: CampaignId, group: GroupId): Future[Option[GroupStatus.Value]] =
-    db.run {
-      Schema.groupStats
-        .filter(_.campaignId === campaign)
-        .filter(_.groupId === group)
-        .map(_.status)
-        .result
-        .headOption
-    }
-
-  def failedDevices(ns: Namespace, campaign: CampaignId): Future[Set[DeviceId]] =
-    db.run {
-      find(ns, campaign).flatMap { _ =>
-        Schema.deviceUpdates
-          .filter(_.campaignId === campaign)
-          .filter(_.status === DeviceStatus.failed)
-          .map(_.deviceId)
-          .result
-          .map(_.toSet)
-      }
-    }
-
-  def campaignStatsFor(ns: Namespace, campaign: CampaignId): Future[Map[GroupId, Stats]] =
-    db.run {
-      find(ns, campaign).flatMap { _ =>
-        Schema.groupStats
-          .filter(_.campaignId === campaign)
-          .map(r => (r.groupId, r.processed, r.affected))
-          .result
-      }
-    }.map(_.groupBy(_._1).map {
-      case (group, (_, processed, affected) +: _) => (group, Stats(processed, affected))
-    })
-
-  def remainingCampaigns(): Future[Seq[Campaign]] =
-    db.run {
-      Schema.groupStats.join(Schema.campaigns).on(_.campaignId === _.id)
-        .filter(_._1.status === GroupStatus.scheduled)
-        .map(_._2)
-        .result
-    }
-
-  def freshCampaigns(): Future[Seq[Campaign]] =
-    db.run {
-      Schema.groupStats.join(Schema.campaigns).on(_.campaignId === _.id)
-        .filter(_._1.status === GroupStatus.scheduled)
-        .filter(_._1.processed === 0L)
-        .filter(_._1.affected  === 0L)
-        .map(_._2)
-        .result
-    }
-
-  def remainingGroups(campaign: CampaignId): Future[Seq[GroupId]] =
-    db.run {
-      Schema.groupStats
-        .filter(_.campaignId === campaign)
-        .filter(_.status === GroupStatus.scheduled)
-        .map(_.groupId)
-        .result
-    }
-
-  def remainingBatches(campaign: CampaignId, group: GroupId): Future[Option[Long]] =
-    db.run {
-      Schema.groupStats
-        .filter(_.campaignId === campaign)
-        .filter(_.groupId === group)
-        .filter(_.status === GroupStatus.scheduled)
-        .map(_.processed)
-        .result
-        .headOption
-    }
-
-  private[db] def progressGroup(
-    ns: Namespace,
-    campaign: CampaignId,
-    group: GroupId,
-    status: GroupStatus.Value,
-    stats: Stats): Future[Unit] =
-    db.run {
-      if (stats.affected > stats.processed)
-        DBIO.failed(Errors.InvalidCounts)
-      else
-        find(ns, campaign).flatMap { _ =>
-          Schema.groupStats
-            .filter(_.campaignId === campaign)
-            .filter(_.groupId === group)
-            .filter(s => s.affected <= s.processed)
-            .map(s => (s.status, s.processed, s.affected))
-            .update((status, stats.processed, stats.affected))
-            .flatMap {
-            case 0 => Schema.groupStats += GroupStats(campaign, group, status, stats.processed, stats.affected)
-            case _ =>  DBIO.successful(())
-          }
-        }.map(_ => ()).transactionally
-          .handleIntegrityErrors(Errors.CampaignMissing)
-    }
-
-  def completeBatch(
-    ns: Namespace,
-    campaign: CampaignId,
-    group: GroupId,
-    stats: Stats): Future[Unit] =
-    progressGroup(ns, campaign, group, GroupStatus.scheduled, stats)
-
-  def completeGroup(
-    ns: Namespace,
-    campaign: CampaignId,
-    group: GroupId,
-    stats: Stats): Future[Unit] =
-    progressGroup(ns, campaign, group, GroupStatus.launched, stats)
-
-  def cancelCampaign(
-    ns: Namespace,
-    campaign: CampaignId) : Future[Unit] =
-    db.run {
-      find(ns, campaign).flatMap { _ =>
-        Schema.groupStats
-          .filter(_.campaignId === campaign)
-          .map(_.status)
-          .update(GroupStatus.cancelled)
-          .map(_ => ())
-      }
-    }
-
-  def scheduleDevice(campaign: CampaignId, update: UpdateId, device: DeviceId): Future[Unit] =
-    db.run {
-      (Schema.deviceUpdates += DeviceUpdate(campaign, update, device, DeviceStatus.scheduled))
-        .map(_ => ())
-    }
-
-  def finishDevice(update: UpdateId, device: DeviceId, status: DeviceStatus.Value): Future[Unit] =
-    db.run {
-      Schema.deviceUpdates
-        .filter(_.updateId === update)
-        .filter(_.deviceId === device)
-        .map(_.status)
-        .update(status)
-        .flatMap {
-        case 0 => DBIO.failed(Errors.DeviceNotScheduled)
-        case _ => DBIO.successful(())
-      }.map(_ => ())
-    }
-
-  def countFinished(ns: Namespace, campaignId: CampaignId): Future[Long] =
-    db.run {
-      Schema.campaigns
-        .filter(_.namespace === ns)
-        .filter(_.id === campaignId)
-        .flatMap { campaign =>
-        Schema.deviceUpdates
-          .filter(_.campaignId === campaign.id)
-          .filter(_.updateId === campaign.update)
-          .filter(d => d.status === DeviceStatus.successful ||
-                       d.status === DeviceStatus.failed)
-          .map(_.deviceId)
-      }.distinct
-        .length
-        .result
-    }.map(_.toLong)
-
+  private[db] def progressGroup(ns: Namespace,
+                                campaign: CampaignId,
+                                group: GroupId,
+                                status: GroupStatus,
+                                stats: Stats): Future[Unit] =
+    if (stats.affected > stats.processed)
+      Future.failed(Errors.InvalidCounts)
+    else
+      groupStatsRepo.updateGroupStats(campaign, group, status, stats)
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
@@ -1,0 +1,189 @@
+package com.advancedtelematic.campaigner.db
+
+import com.advancedtelematic.campaigner.data.DataType.CampaignStatus._
+import com.advancedtelematic.campaigner.data.DataType.DeviceStatus._
+import com.advancedtelematic.campaigner.data.DataType.GroupStatus._
+import com.advancedtelematic.campaigner.data.DataType._
+import com.advancedtelematic.campaigner.db.Schema.{GroupStatsTable}
+import com.advancedtelematic.campaigner.http.Errors
+import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
+import com.advancedtelematic.libats.slick.db.SlickExtensions._
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+
+import scala.concurrent.{ExecutionContext, Future}
+import slick.jdbc.MySQLProfile.api._
+
+trait CampaignSupport {
+  def campaignRepo(implicit db: Database, ec: ExecutionContext) = new CampaignRepository()
+}
+
+trait GroupStatsSupport {
+  def groupStatsRepo(implicit db: Database, ec: ExecutionContext) = new GroupStatsRepository()
+}
+
+trait DeviceUpdateSupport {
+  def deviceUpdateRepo(implicit db: Database, ec: ExecutionContext) = new DeviceUpdateRepository()
+}
+
+protected [db] class DeviceUpdateRepository()(implicit db: Database, ec: ExecutionContext) {
+
+  protected [db] def findByCampaignAction(campaign: CampaignId, status: DeviceStatus): DBIO[Set[DeviceId]] =
+    Schema.deviceUpdates
+      .filter(_.campaignId === campaign)
+      .filter(_.status === status)
+      .map(_.deviceId)
+      .result
+      .map(_.toSet)
+
+  def setUpdateStatus(update: UpdateId, device: DeviceId, status: DeviceStatus): Future[Unit] = db.run {
+    Schema.deviceUpdates
+      .filter(_.updateId === update)
+      .filter(_.deviceId === device)
+      .map(_.status)
+      .update(status)
+      .flatMap {
+        case 0 => DBIO.failed(Errors.DeviceNotScheduled)
+        case _ => DBIO.successful(())
+      }.map(_ => ())
+  }
+
+  def persist(update: DeviceUpdate): Future[Unit] = db.run {
+    (Schema.deviceUpdates += update).map(_ => ())
+  }
+}
+
+protected [db] class GroupStatsRepository()(implicit db: Database, ec: ExecutionContext) {
+  def updateGroupStats(campaign: CampaignId, group: GroupId, status: GroupStatus, stats: Stats): Future[Unit] =
+    db.run {
+      Schema.groupStats
+        .insertOrUpdate(GroupStats(campaign, group, status, stats.processed, stats.affected))
+        .map(_ => ())
+        .handleIntegrityErrors(Errors.CampaignMissing)
+    }
+
+  protected [db] def findByCampaignAction(campaign: CampaignId): DBIO[Seq[GroupStats]] =
+    Schema.groupStats
+      .filter(_.campaignId === campaign)
+      .result
+
+  protected [db] def persistManyAction(campaign: CampaignId, groups: Set[GroupId]): DBIO[Unit] =
+    DBIO.sequence {
+      groups.toSeq.map { group =>
+        persistAction(GroupStats(campaign, group, GroupStatus.scheduled, 0, 0))
+      }
+    }.map(_ => ())
+
+  protected [db] def persistAction(stats: GroupStats): DBIO[Unit] = (Schema.groupStats += stats).map(_ => ())
+
+  def aggregatedStatus(campaign: CampaignId): Future[CampaignStatus] = {
+    def groupStats(status: GroupStatus) =
+      Schema.groupStats
+        .filter(_.campaignId === campaign)
+        .filter(_.status === status)
+        .length.result
+
+    db.run {
+      for {
+        scheduled <- groupStats(GroupStatus.scheduled)
+        launched  <- groupStats(GroupStatus.launched)
+        cancelled <- groupStats(GroupStatus.cancelled)
+        status     = (scheduled, launched, cancelled) match {
+          case (_, _, c) if c > 0 => CampaignStatus.cancelled
+          case (0, l, _) if l > 0 => CampaignStatus.launched
+          case (0, 0, _)          => CampaignStatus.prepared
+          case _                  => CampaignStatus.scheduled
+        }
+      } yield status
+    }
+  }
+
+  def groupStatusFor(campaign: CampaignId, group: GroupId): Future[Option[GroupStatus]] =
+    db.run {
+      Schema.groupStats
+        .filter(_.campaignId === campaign)
+        .filter(_.groupId === group)
+        .map(_.status)
+        .result
+        .headOption
+    }
+
+  def findScheduled(campaign: CampaignId, groupId: Option[GroupId] = None): Future[Seq[GroupStats]] = db.run {
+    Schema.groupStats
+      .filter(_.campaignId === campaign)
+      .filter(_.status === GroupStatus.scheduled)
+      .maybeFilter(_.groupId === groupId)
+      .result
+  }
+
+  def cancel(campaign: CampaignId): Future[Unit] = db.run {
+    Schema.groupStats
+      .filter(_.campaignId === campaign)
+      .map(_.status)
+      .update(GroupStatus.cancelled)
+      .map(_ => ())
+  }
+}
+
+protected class CampaignRepository()(implicit db: Database, ec: ExecutionContext) {
+
+  import com.advancedtelematic.libats.slick.db.SlickAnyVal._
+
+  def persist(campaign: Campaign, groups: Set[GroupId]): Future[CampaignId] =
+    db.run {
+      val f = for {
+        _ <- Schema.campaigns += campaign
+        _ <- Schema.campaignGroups ++= groups.map(g => (campaign.id, g))
+      } yield campaign.id
+
+      f.transactionally.handleIntegrityErrors(Errors.ConflictingCampaign)
+    }
+
+  def find(ns: Namespace, campaign: CampaignId): Future[Campaign] =
+    db.run(findAction(ns, campaign))
+
+  protected[db] def findAction(ns: Namespace, campaign: CampaignId): DBIO[Campaign] =
+    Schema.campaigns
+      .filter(_.namespace === ns)
+      .filter(_.id === campaign)
+      .result
+      .failIfNotSingle(Errors.CampaignMissing)
+
+  def findCampaign(ns: Namespace, campaign: CampaignId): Future[Campaign] =
+    db.run(findAction(ns, campaign))
+
+  def findAllScheduled(filter: GroupStatsTable => Rep[Boolean] = _ => true.bind): Future[Seq[Campaign]] = {
+    db.run {
+      Schema.groupStats.join(Schema.campaigns).on(_.campaignId === _.id)
+        .filter { case (groupStats, _) => groupStats.status === GroupStatus.scheduled }
+        .filter { case (groupStats, _) => filter(groupStats) }
+        .map(_._2)
+        .result
+    }
+  }
+
+  def updateName(ns: Namespace, campaign: CampaignId, name: String): Future[Unit] =
+    db.run {
+      findAction(ns, campaign).flatMap { _ =>
+        Schema.campaigns
+          .filter(_.id === campaign)
+          .map(_.name)
+          .update(name)
+          .map(_ => ())
+          .handleIntegrityErrors(Errors.ConflictingCampaign)
+      }
+    }
+
+  def countFinished(ns: Namespace, campaign: CampaignId): Future[Long] = db.run {
+    Schema.campaigns
+      .filter(_.namespace === ns)
+      .filter(_.id === campaign)
+      .join(Schema.deviceUpdates)
+      .on { case (campaign, update) => campaign.update === update.updateId && campaign.id === update.campaignId}
+      .filter { case (_, update) => update.status === DeviceStatus.successful || update.status === DeviceStatus.failed }
+      .distinct
+      .length
+      .result
+      .map(_.toLong)
+  }
+}

--- a/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
@@ -6,40 +6,24 @@ import akka.http.scaladsl.server.Directives._
 import com.advancedtelematic.campaigner.Settings
 import com.advancedtelematic.campaigner.data.Codecs._
 import com.advancedtelematic.campaigner.data.DataType._
-import com.advancedtelematic.campaigner.db.CampaignSupport
+import com.advancedtelematic.campaigner.db.Campaigns
 import com.advancedtelematic.libats.auth.AuthedNamespaceScope
 import com.advancedtelematic.libats.data.Namespace
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+
 import scala.concurrent.{ExecutionContext, Future}
 import slick.jdbc.MySQLProfile.api._
 
 class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope])
                       (implicit db: Database, ec: ExecutionContext)
-  extends CampaignSupport
-  with Settings {
+  extends Settings {
+
+  val campaigns = Campaigns()
 
   def createCampaign(ns: Namespace, request: CreateCampaign): Future[CampaignId] = {
     val campaign = request.mkCampaign(ns)
-    Campaigns.persist(campaign, request.groups)
-      .map(_ => campaign.id)
+    campaigns.create(campaign, request.groups)
   }
-
-  def getCampaign(ns: Namespace, id: CampaignId): Future[GetCampaign] = for {
-    c      <- Campaigns.findCampaign(ns, id)
-    groups <- Campaigns.findGroups(ns, c.id)
-  } yield GetCampaign(c, groups)
-
-  def launchCampaign(ns: Namespace, id: CampaignId): Future[Unit] =  for {
-    groups <- Campaigns.findGroups(ns, id)
-    ()     <- Campaigns.scheduleGroups(ns, id, groups)
-  } yield ()
-
-  def getStats(ns: Namespace, id: CampaignId): Future[CampaignStats] = for {
-    status   <- Campaigns.aggregatedStatus(id)
-    finished <- Campaigns.countFinished(ns, id)
-    failed   <- Campaigns.failedDevices(ns, id)
-    stats    <- Campaigns.campaignStatsFor(ns, id)
-  } yield CampaignStats(id, status, finished, failed, stats)
 
   val route =
     extractAuth { auth =>
@@ -52,22 +36,21 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope])
         } ~
         pathPrefix(CampaignId.Path) { id =>
           (get & pathEnd) {
-            complete(getCampaign(ns, id))
+            complete(campaigns.findCampaign(ns, id))
           } ~
           (put & pathEnd & entity(as[UpdateCampaign])) { updated =>
-            complete(Campaigns.update(ns, id, updated.name).map(_ => ()))
+            complete(campaigns.update(ns, id, updated.name))
           } ~
           (post & path("launch")) {
-            complete(launchCampaign(ns, id))
+            complete(campaigns.launch(ns, id))
           } ~
           (get & path("stats")) {
-            complete(getStats(ns, id))
+            complete(campaigns.campaignStats(ns, id))
           } ~
           (post & path("cancel")) {
-            complete(Campaigns.cancelCampaign(ns, id).map(_ => ()))
+            complete(campaigns.cancelCampaign(ns, id))
           }
         }
       }
     }
-
 }

--- a/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSchedulerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSchedulerSpec.scala
@@ -3,8 +3,10 @@ package com.advancedtelematic.campaigner.actor
 import akka.testkit.TestProbe
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
+import com.advancedtelematic.campaigner.db.Campaigns
 import com.advancedtelematic.campaigner.util.{ActorSpec, CampaignerSpec}
 import org.scalacheck.Arbitrary
+
 import scala.collection.JavaConverters._
 
 class CampaignSchedulerSpec extends ActorSpec[CampaignScheduler] with CampaignerSpec {
@@ -13,14 +15,17 @@ class CampaignSchedulerSpec extends ActorSpec[CampaignScheduler] with Campaigner
   import CampaignScheduler._
   import scala.concurrent.duration._
 
+  val campaigns = Campaigns()
+
   "campaign scheduler" should "trigger updates for each group" in {
 
     val campaign = arbitrary[Campaign].sample.get
     val groups   = arbitrary[Set[GroupId]].sample.get
     val parent   = TestProbe()
 
-    Campaigns.persist(campaign, groups).futureValue
-    Campaigns.scheduleGroups(campaign.namespace, campaign.id, groups).futureValue
+    campaigns.create(campaign, groups).futureValue
+    campaigns.scheduleGroups(campaign.namespace, campaign.id, groups).futureValue
+
     parent.childActorOf(CampaignScheduler.props(
       registry,
       director,

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -4,9 +4,10 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.RawHeader
 import cats.syntax.show._
 import com.advancedtelematic.campaigner.data.Codecs._
+import com.advancedtelematic.campaigner.data.DataType.CampaignStatus.CampaignStatus
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
-import com.advancedtelematic.campaigner.util.{ResourceSpec, CampaignerSpec}
+import com.advancedtelematic.campaigner.util.{CampaignerSpec, ResourceSpec}
 import com.advancedtelematic.libats.data.Namespace
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import org.scalacheck.Arbitrary._
@@ -98,7 +99,7 @@ class CampaignResourceSpec extends CampaignerSpec with ResourceSpec {
 
   }
 
-  def checkStatus(id: CampaignId, expected: CampaignStatus.Value) =
+  def checkStatus(id: CampaignId, expected: CampaignStatus) =
     Get(apiUri(s"campaigns/${id.show}/stats")).withHeaders(header) ~> routes ~> check {
       status shouldBe OK
       val result = responseAs[CampaignStats]

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ActorSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ActorSpec.scala
@@ -4,14 +4,12 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.advancedtelematic.campaigner.Settings
 import com.advancedtelematic.campaigner.client._
-import com.advancedtelematic.campaigner.db.CampaignSupport
 import com.advancedtelematic.libats.test.DatabaseSpec
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 import scala.concurrent.ExecutionContext
 
 abstract class ActorSpec[T](implicit m: reflect.Manifest[T])
     extends TestKit(ActorSystem(m.toString.split("""\.""").last + "Spec"))
-    with CampaignSupport
     with FlatSpecLike
     with Settings
     with BeforeAndAfterAll


### PR DESCRIPTION
In master, Campaigner is acting as a massive db repository for all
Schema Tables. IMO this should be avoided. `Campaigns` should
understand only business logic and interact with low level db
objects (DBIO/Query) as little as possible, delegating to specific
repository objects instead.

For each db table, slick logic should be encapsulated in it's own
repository class. This encourages reuse of query methods and slick
methods dealing with the database, while mantaining the repository
classes and slick queries relatively readable.

I also simplified some queries, I think they are equivalent but
probably it's worth doing a double check.

See changes for details.

Please in the future don't merge such big changes without at least one
approval, this kind of refactor should be done before code is in
master.