### PR TITLE
[PRO-3570] add endpoint to fetch campaigns within namespace

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -6,12 +6,12 @@ import com.advancedtelematic.campaigner.data.DataType.GroupStatus.GroupStatus
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.http.Errors
 import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
-import slick.jdbc.MySQLProfile.api._
 import com.advancedtelematic.libats.slick.db.SlickExtensions._
 import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
-
 import scala.concurrent.{ExecutionContext, Future}
+import slick.jdbc.MySQLProfile.api._
 
 object Campaigns {
   def apply()(implicit db: Database, ec: ExecutionContext): Campaigns = new Campaigns()
@@ -73,8 +73,11 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
   def countFinished(ns: Namespace, campaignId: CampaignId): Future[Long] =
     campaignRepo.countFinished(ns, campaignId)
 
+  def allCampaigns(ns: Namespace, offset: Long, limit: Long): Future[PaginationResult[CampaignId]] =
+    campaignRepo.all(ns, offset, limit)
+
   def findCampaign(ns: Namespace, campaignId: CampaignId): Future[GetCampaign] = for {
-    c <- campaignRepo.findCampaign(ns, campaignId)
+    c <- campaignRepo.find(ns, campaignId)
     groups <- findGroups(ns, c.id)
   } yield GetCampaign(c, groups)
 

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -9,6 +9,7 @@ import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
 import com.advancedtelematic.campaigner.util.{CampaignerSpec, ResourceSpec}
 import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.PaginationResult
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import org.scalacheck.Arbitrary._
 
@@ -29,6 +30,12 @@ class CampaignResourceSpec extends CampaignerSpec with ResourceSpec {
       responseAs[GetCampaign]
     }
 
+  def getCampaignsOk(): PaginationResult[CampaignId] =
+    Get(apiUri("campaigns")).withHeaders(header) ~> routes ~> check {
+      status shouldBe OK
+      responseAs[PaginationResult[CampaignId]]
+    }
+
   "POST and GET /campaigns" should "create a campaign, return the created campaign" in {
     val request = arbitrary[CreateCampaign].sample.get
     val id = createCampaignOk(request)
@@ -44,6 +51,9 @@ class CampaignResourceSpec extends CampaignerSpec with ResourceSpec {
       request.groups
     )
     campaign.createdAt shouldBe campaign.updatedAt
+
+    val campaigns = getCampaignsOk()
+    campaigns.values should contain (id)
   }
 
   "PUT /campaigns/:campaign_id" should "update a campaign" in {


### PR DESCRIPTION
fetching all campaign metadata could be more efficient,
but https://advancedtelematic.atlassian.net/wiki/spaces/OPS/pages/61708854/Multi-ECU+update+builder+and+campaign+manager (5.1) suggests that we need the stats per campaign anyway (which is not yet included in `GetCampaign`).

on the other hand, `GetCampaign` includes groups per campaign, which would make this call unneccessary expensive.