### PR TITLE
[PRO-4049] cancelling campaigns also propagates …

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/Boot.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/Boot.scala
@@ -2,6 +2,7 @@ package com.advancedtelematic.campaigner
 
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.{Directives, Route}
+import com.advancedtelematic.campaigner.client.DirectorHttpClient
 import com.advancedtelematic.campaigner.http.Routes
 import com.advancedtelematic.libats.http.BootApp
 import com.advancedtelematic.libats.http.LogDirectives._
@@ -46,9 +47,11 @@ object Boot extends BootApp
 
   log.info(s"Starting $version on http://$host:$port")
 
+  val director = new DirectorHttpClient(directorUri)
+
   val routes: Route =
     (versionHeaders(version) & logResponseMetrics(projectName)) {
-      new Routes().routes
+      new Routes(director).routes
     }
 
   Http().bindAndHandle(routes, host, port)

--- a/src/main/scala/com/advancedtelematic/campaigner/client/DirectorClient.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/client/DirectorClient.scala
@@ -10,9 +10,15 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait DirectorClient {
 
-  def setMultiUpdateTarget(ns: Namespace,
-                           update: UpdateId,
-                           devices: Seq[DeviceId]): Future[Seq[DeviceId]]
+  def setMultiUpdateTarget(
+    ns: Namespace,
+    update: UpdateId,
+    devices: Seq[DeviceId]): Future[Seq[DeviceId]]
+
+  def cancelUpdate(
+    ns: Namespace,
+    devices: Seq[DeviceId]): Future[Seq[DeviceId]]
+
 }
 
 class DirectorHttpClient(uri: Uri)
@@ -22,10 +28,26 @@ class DirectorHttpClient(uri: Uri)
   import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
   import io.circe.syntax._
 
-  override def setMultiUpdateTarget(ns: Namespace,
-                                    update: UpdateId,
-                                    devices: Seq[DeviceId]): Future[Seq[DeviceId]] = {
+  override def setMultiUpdateTarget(
+    ns: Namespace,
+    update: UpdateId,
+    devices: Seq[DeviceId]): Future[Seq[DeviceId]] = {
+
     val path   = uri.path / "api" / "v1" / "admin" / "multi_target_updates" / update.show
+    val entity = HttpEntity(ContentTypes.`application/json`, devices.asJson.noSpaces)
+    val req    = HttpRequest(
+      method = HttpMethods.PUT,
+      uri    = uri.withPath(path),
+      entity = entity
+    )
+    execHttp[Seq[DeviceId]](ns, req)
+  }
+
+  override def cancelUpdate(
+    ns: Namespace,
+    devices: Seq[DeviceId]): Future[Seq[DeviceId]] = {
+
+    val path   = uri.path / "api" / "v1" / "admin" / "devices" / "queue" / "cancel"
     val entity = HttpEntity(ContentTypes.`application/json`, devices.asJson.noSpaces)
     val req    = HttpRequest(
       method = HttpMethods.PUT,

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -33,25 +33,26 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
       .map(_.map(_.processed))
 
   def completeBatch(
-                     ns: Namespace,
-                     campaign: CampaignId,
-                     group: GroupId,
-                     stats: Stats): Future[Unit] =
+    ns: Namespace,
+    campaign: CampaignId,
+    group: GroupId,
+    stats: Stats): Future[Unit] =
     progressGroup(ns, campaign, group, GroupStatus.scheduled, stats)
 
   def completeGroup(
-                     ns: Namespace,
-                     campaign: CampaignId,
-                     group: GroupId,
-                     stats: Stats): Future[Unit] =
+    ns: Namespace,
+    campaign: CampaignId,
+    group: GroupId,
+    stats: Stats): Future[Unit] =
     progressGroup(ns, campaign, group, GroupStatus.launched, stats)
 
   def cancelCampaign(
-                      ns: Namespace,
-                      campaign: CampaignId) : Future[Unit] =
-    campaignRepo.find(ns, campaign).flatMap { _ =>
-      groupStatsRepo.cancel(campaign)
-    }
+    ns: Namespace,
+    campaign: CampaignId): Future[Set[DeviceId]] = for {
+      _    <- campaignRepo.find(ns, campaign)
+      _    <- groupStatsRepo.cancel(campaign)
+      devs <- scheduledDevices(ns, campaign)
+    } yield devs
 
   def failedDevices(ns: Namespace, campaign: CampaignId): Future[Set[DeviceId]] = db.run {
     campaignRepo.findAction(ns, campaign).flatMap { _ =>
@@ -75,6 +76,9 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
 
   def finishDevice(update: UpdateId, device: DeviceId, status: DeviceStatus): Future[Unit] =
     deviceUpdateRepo.setUpdateStatus(update, device, status)
+
+  def finishDevices(campaign: CampaignId, devices: Seq[DeviceId], status: DeviceStatus): Future[Unit] =
+    deviceUpdateRepo.setUpdateStatus(campaign, devices, status)
 
   def countFinished(ns: Namespace, campaignId: CampaignId): Future[Long] =
     campaignRepo.countFinished(ns, campaignId)

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Routes.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Routes.scala
@@ -2,6 +2,7 @@ package com.advancedtelematic.campaigner.http
 
 import akka.http.scaladsl.server.{Directives, Route}
 import com.advancedtelematic.campaigner.VersionInfo
+import com.advancedtelematic.campaigner.client.DirectorClient
 import com.advancedtelematic.libats.auth.NamespaceDirectives
 import com.advancedtelematic.libats.http.DefaultRejectionHandler.rejectionHandler
 import com.advancedtelematic.libats.http.ErrorHandler
@@ -9,7 +10,8 @@ import com.advancedtelematic.libats.slick.monitoring.DbHealthResource
 import scala.concurrent.ExecutionContext
 import slick.jdbc.MySQLProfile.api._
 
-class Routes(implicit val db: Database, ec: ExecutionContext)
+class Routes(director: DirectorClient)
+            (implicit val db: Database, ec: ExecutionContext)
     extends VersionInfo {
 
   import Directives._
@@ -20,7 +22,7 @@ class Routes(implicit val db: Database, ec: ExecutionContext)
     handleRejections(rejectionHandler) {
       ErrorHandler.handleErrors {
         pathPrefix("api" / "v2") {
-          new CampaignResource(extractAuth).route
+          new CampaignResource(extractAuth, director).route
         } ~ DbHealthResource(versionMap).route
       }
     }

--- a/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSchedulerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSchedulerSpec.scala
@@ -53,6 +53,11 @@ class CampaignSchedulerSpec extends ActorSpec[CampaignScheduler] with Campaigner
         update: UpdateId,
         devices: Seq[DeviceId]
       ): Future[Seq[DeviceId]] = FastFuture.successful(Seq.empty)
+
+      override def cancelUpdate(
+        ns: Namespace,
+        devs: Seq[DeviceId]
+      ): Future[Seq[DeviceId]] = FastFuture.successful(Seq.empty)
     }
 
     campaigns.create(campaign, groups).futureValue

--- a/src/test/scala/com/advancedtelematic/campaigner/util/FakeClients.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/FakeClients.scala
@@ -42,4 +42,11 @@ class FakeDirectorClient extends DirectorClient {
     FastFuture.successful(devs)
   }
 
+  override def cancelUpdate(
+    ns: Namespace,
+    devices: Seq[DeviceId]): Future[Seq[DeviceId]] = {
+    val devs = Gen.someOf(devices).sample.get
+    FastFuture.successful(devs)
+  }
+
 }

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -1,6 +1,7 @@
 package com.advancedtelematic.campaigner.util
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.advancedtelematic.campaigner.client.FakeDirectorClient
 import com.advancedtelematic.campaigner.http.Routes
 import com.advancedtelematic.libats.test.DatabaseSpec
 import org.scalatest.Suite
@@ -10,7 +11,8 @@ trait ResourceSpec extends ScalatestRouteTest
   self: Suite =>
 
   def apiUri(path: String): String = "/api/v2/" + path
+  val director = new FakeDirectorClient
 
-  lazy val routes = new Routes().routes
+  lazy val routes = new Routes(director).routes
 
 }


### PR DESCRIPTION
… cancellation of updates to director

NOTE: as the update id is not transmitted, this will basically clear the
queue of all devices previously affected by this campaign