### PR TITLE
Make the tests more reliable

### DIFF
--- a/src/test/scala/com/advancedtelematic/campaigner/actor/GroupSchedulerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/GroupSchedulerSpec.scala
@@ -77,7 +77,6 @@ class GroupSchedulerSpec extends ActorSpec[GroupScheduler] with CampaignerSpec {
     val campaign = arbitrary[Campaign].sample.get
     val group    = GroupId.generate()
     val n        = Gen.choose(0, batch-1).sample.get
-    println(n)
     val devs     = Gen.listOfN(n, genDeviceId).sample.get
 
     campaigns.create(campaign, Set(group)).futureValue
@@ -93,5 +92,4 @@ class GroupSchedulerSpec extends ActorSpec[GroupScheduler] with CampaignerSpec {
     director.updates.get(campaign.updateId) should be
       campaigns.scheduledDevices(campaign.namespace, campaign.id).futureValue
   }
-
 }

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -1,18 +1,20 @@
 package com.advancedtelematic.campaigner.util
 
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import com.advancedtelematic.campaigner.client.FakeDirectorClient
 import com.advancedtelematic.campaigner.http.Routes
 import com.advancedtelematic.libats.test.DatabaseSpec
 import org.scalatest.Suite
+import org.scalatest.time.{Seconds, Span}
 
 trait ResourceSpec extends ScalatestRouteTest
   with DatabaseSpec {
   self: Suite =>
 
+  implicit val defaultTimeout = RouteTestTimeout(Span(5, Seconds))
+
   def apiUri(path: String): String = "/api/v2/" + path
   val director = new FakeDirectorClient
 
   lazy val routes = new Routes(director).routes
-
 }


### PR DESCRIPTION
By making sure we schedule the next batch after we have stored the
current ones in the database.