### PR TITLE
Save errors in database when campaign fails

### DIFF
--- a/src/main/resources/db/migration/V11__add_campaign_errors.sql
+++ b/src/main/resources/db/migration/V11__add_campaign_errors.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `campaign_errors` (
+  `campaign_id` CHAR(36),
+  `error_count` INT NOT NULL,
+  `last_error` VARCHAR(1024) NOT NULL,
+  `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+   PRIMARY KEY (`campaign_id`)
+);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%.-1level|%date{ISO8601, UTC}|%logger{36}|%message%n%exception</pattern>
+            <pattern>%.-1level|%date{ISO8601, UTC}|%X{akkaSource:--}|%logger{36}|%message%n%exception</pattern>
         </encoder>
     </appender>
 

--- a/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
@@ -30,7 +30,7 @@ object DaemonBoot extends BootApp
 
   implicit val _db = db
 
-  log.info("Starting campaigner daemon")
+  log.info(s"Starting campaigner daemon $version")
 
   val deviceRegistry = new DeviceRegistryHttpClient(deviceRegistryUri, defaultHttpClient)
   val director = new DirectorHttpClient(directorUri, defaultHttpClient)

--- a/src/main/scala/com/advancedtelematic/campaigner/actor/CampaignScheduler.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/actor/CampaignScheduler.scala
@@ -1,28 +1,31 @@
 package com.advancedtelematic.campaigner.actor
 
-import akka.actor.{Actor, ActorLogging, Props, Status}
+import akka.actor.{Actor, ActorLogging, PoisonPill, Props, Status, SupervisorStrategy, Terminated}
 import com.advancedtelematic.campaigner.client._
 import com.advancedtelematic.campaigner.data.DataType._
-import com.advancedtelematic.campaigner.db.Campaigns
+import com.advancedtelematic.campaigner.db.{CampaignErrorsSupport, Campaigns}
 import slick.jdbc.MySQLProfile.api._
+import cats.syntax.option._
 
 import scala.concurrent.duration._
 import cats.syntax.show._
 
 object CampaignScheduler {
 
+  val MAX_CAMPAIGN_ERROR_COUNT = 10
+  val MAX_DELAY = 5.minutes
+
   private object NextGroup
   private final case class ScheduleGroup(group: GroupId)
-  final case class CampaignComplete(campaign: CampaignId)
+  final case class CampaignSchedulingComplete(campaign: CampaignId)
+  final case class CampaignSchedulingFailed(campaignId: CampaignId)
 
   def props(registry: DeviceRegistryClient,
             director: DirectorClient,
             campaign: Campaign,
             delay: FiniteDuration,
-            batchSize: Long)
-           (implicit db: Database): Props =
+            batchSize: Long)(implicit db: Database): Props =
     Props(new CampaignScheduler(registry, director, campaign, delay, batchSize))
-
 }
 
 class CampaignScheduler(registry: DeviceRegistryClient,
@@ -31,7 +34,7 @@ class CampaignScheduler(registry: DeviceRegistryClient,
                         delay: FiniteDuration,
                         batchSize: Long)
                        (implicit db: Database) extends Actor
-  with ActorLogging {
+  with ActorLogging with CampaignErrorsSupport {
 
   import CampaignScheduler._
   import GroupScheduler._
@@ -43,18 +46,19 @@ class CampaignScheduler(registry: DeviceRegistryClient,
   override def preStart(): Unit =
     self ! NextGroup
 
-  private def schedule(group: GroupId): Unit =
-    actorOf(GroupScheduler.props(
-      registry,
-      director,
-      delay,
-      batchSize,
-      campaign,
-      group),
-      s"group-scheduler-${group.show}"
-    )
+  private def startGroupScheduler(group: GroupId): Unit = {
+    val props = GroupScheduler.props(registry, director, delay, batchSize, campaign, group)
+    val child = actorOf(props, s"group-scheduler-${group.show}")
+    context.watch(child)
+  }
 
-  def receive: Receive = {
+  override def supervisorStrategy: SupervisorStrategy = SupervisorStrategy.stoppingStrategy
+
+  private def calculateNextDelay(currentDelay: FiniteDuration)(implicit ord: Ordering[FiniteDuration]): FiniteDuration = {
+    ord.min(currentDelay * 2, MAX_DELAY)
+  }
+
+  def scheduling(currentDelay: FiniteDuration, errorCount: Int, receivedError: Option[Throwable]): Receive = {
     case NextGroup =>
       log.debug(s"next group")
       campaigns.remainingGroups(campaign.id)
@@ -63,19 +67,49 @@ class CampaignScheduler(registry: DeviceRegistryClient,
 
     case Some(group: GroupId) =>
       log.debug(s"scheduling $group")
-      schedule(group)
+      startGroupScheduler(group)
 
     case None =>
-      parent ! CampaignComplete(campaign.id)
-      // TODO: Should move to finished
+      parent ! CampaignSchedulingComplete(campaign.id)
+      log.info(s"Scheduling of ${campaign.id} is complete")
       context.stop(self)
+
+    case GroupSchedulerError(cause) =>
+      become(scheduling(currentDelay, errorCount, cause.some))
+
+    case Terminated(_) =>
+      val nextDelay = calculateNextDelay(currentDelay)
+
+      addCampaignError(receivedError)
+
+      if(errorCount > MAX_CAMPAIGN_ERROR_COUNT) {
+        log.warning(s"Giving up scheduling groups for ${campaign.id} after $errorCount tries")
+        parent ! CampaignSchedulingFailed(campaign.id)
+        context.stop(self)
+      } else {
+        log.info(s"Could not schedule groups for ${campaign.id} after $errorCount tries, trying again in $nextDelay")
+        system.scheduler.scheduleOnce(nextDelay, self, NextGroup)
+      }
+
+      context.become(scheduling(nextDelay, errorCount + 1, receivedError = None))
 
     case GroupComplete(group) =>
       log.debug(s"$group complete")
+      context.unwatch(sender)
+      sender ! PoisonPill
       self ! NextGroup
 
     case Status.Failure(ex) =>
-      log.error(ex, s"An Error occurred ${ex.getMessage}")
+      addCampaignError(receivedError)
+      log.error(ex, s"An error occurred scheduling a campaign ${ex.getMessage}")
       throw ex
   }
+
+  private def addCampaignError(error: Option[Throwable]): Unit = {
+    campaignErrorsRepo.addError(campaign.id, error.map(_.getMessage).getOrElse("Unknown error")).failed.foreach { ex =>
+      log.error(ex, "Could not save campaign error to database")
+    }
+  }
+
+  override def receive: Receive = scheduling(delay, errorCount = 0, receivedError = None)
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisor.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisor.scala
@@ -1,16 +1,14 @@
 package com.advancedtelematic.campaigner.actor
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Status}
-import akka.pattern.{Backoff, BackoffSupervisor}
 import akka.stream.Materializer
 import com.advancedtelematic.campaigner.client._
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.db.Campaigns
 import com.advancedtelematic.libats.data.DataType.Namespace
+import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.duration._
-import slick.jdbc.MySQLProfile.api._
-import cats.syntax.show._
 
 object CampaignSupervisor {
 
@@ -54,10 +52,6 @@ class CampaignSupervisor(registry: DeviceRegistryClient,
     // periodically clear out cancelled campaigns
     scheduler.schedule(0.milliseconds, pollingTimeout, self, CleanUpCampaigns)
 
-    // periodically (re-)schedule non-completed campaigns
-    scheduler.schedule(0.milliseconds, pollingTimeout, self, PickUpCampaigns)
-
-    // TODO:SM On start it always runs this twice...
     // pick up campaigns where they left
     campaigns
       .remainingCampaigns(CampaignScheduler.MAX_CAMPAIGN_ERROR_COUNT)
@@ -107,24 +101,31 @@ class CampaignSupervisor(registry: DeviceRegistryClient,
 
     case ResumeCampaigns(runningCampaigns) if runningCampaigns.nonEmpty =>
       log.info(s"resume campaigns ${runningCampaigns.map(_.id)}")
+
       // only create schedulers for campaigns without a scheduler
       val newlyScheduled =
         runningCampaigns
           .filterNot(c => campaignSchedulers.contains(c.id))
           .map(c => c.id -> scheduleCampaign(c))
           .toMap
+
+      scheduler.scheduleOnce(pollingTimeout, self, PickUpCampaigns)
+
       if (newlyScheduled.nonEmpty) {
-        become(supervising(campaignSchedulers ++ newlyScheduled))
         parent ! CampaignsScheduled(newlyScheduled.keySet)
+        become(supervising(campaignSchedulers ++ newlyScheduled))
       } else
         log.debug(s"Not creating scheduler for campaigns, scheduler already exists")
 
+    case ResumeCampaigns(runningCampaigns) if runningCampaigns.isEmpty =>
+      scheduler.scheduleOnce(pollingTimeout, self, PickUpCampaigns)
+
     case CampaignSchedulingFailed(id) =>
-      // TODO:SM Move campaign to failed when that state exists
+      // TODO Move campaign to failed when that state exists
       become(supervising(campaignSchedulers - id))
 
     case CampaignSchedulingComplete(id) =>
-      log.info(s"$id completed")
+      log.info(s"$id scheduling supervision completed")
       parent ! CampaignSchedulingComplete(id)
       become(supervising(campaignSchedulers - id))
 

--- a/src/main/scala/com/advancedtelematic/campaigner/actor/GroupScheduler.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/actor/GroupScheduler.scala
@@ -88,6 +88,7 @@ class GroupScheduler(registry: DeviceRegistryClient,
 
     case msg: BatchComplete =>
       parent ! msg
+
       scheduler.scheduleOnce(delay, self, NextBatch)
 
     case msg: GroupComplete =>

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -179,4 +179,6 @@ object DataType {
     type MetadataType = Value
     val DESCRIPTION, ESTIMATED_INSTALLATION_DURATION, ESTIMATED_PREPARATION_DURATION = Value
   }
+
+  case class CampaignErrors(campaign: CampaignId, errorCount: Int, lastError: String)
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -33,7 +33,7 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
 
   def remainingCancelling(): Future[Seq[(Namespace, CampaignId)]] = cancelTaskRepo.findInprogress()
 
-  def remainingCampaigns(): Future[Seq[Campaign]] = campaignRepo.findAllScheduled()
+  def remainingCampaigns(maxErrors: Int): Future[Seq[Campaign]] = campaignRepo.findAllScheduled(maxErrors)()
 
   def remainingGroups(campaign: CampaignId): Future[Seq[GroupId]] =
     groupStatsRepo.findScheduled(campaign).map(_.map(_.group))
@@ -60,8 +60,8 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
   def freshCancelled(): Future[Seq[(Namespace, CampaignId)]] =
     cancelTaskRepo.findPending()
 
-  def freshCampaigns(): Future[Seq[Campaign]] =
-    campaignRepo.findAllScheduled { groupStats =>
+  def freshCampaigns(maxErrors: Int): Future[Seq[Campaign]] =
+    campaignRepo.findAllScheduled(maxErrors) { groupStats =>
       groupStats.processed === 0L && groupStats.affected === 0L
     }
 

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -127,6 +127,18 @@ object Schema {
 
     override def * : ProvenShape[Update] = (uuid, updateId, updateSourceType, namespace, name, description, createdAt, updatedAt) <> (fromRow, toRow)
   }
+
   protected [db] val updates = TableQuery[UpdatesTable]
 
+  class CampaignErrorsTable(tag: Tag) extends Table[CampaignErrors](tag, "campaign_errors") {
+    def campaignId = column[CampaignId]("campaign_id")
+    def errorCount = column[Int]("error_count")
+    def lastError = column[String]("last_error")
+
+    def pk = primaryKey("campaign_errors_pk", campaignId)
+
+    override def * = (campaignId, errorCount, lastError) <> ((CampaignErrors.apply _).tupled, CampaignErrors.unapply)
+  }
+
+  protected [db] val campaignErrors = TableQuery[CampaignErrorsTable]
 }

--- a/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSchedulerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSchedulerSpec.scala
@@ -1,20 +1,23 @@
 package com.advancedtelematic.campaigner.actor
 
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.PoisonPill
 import akka.http.scaladsl.util.FastFuture
 import akka.testkit.TestProbe
 import cats.data.NonEmptyList
 import com.advancedtelematic.campaigner.client._
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
-import com.advancedtelematic.campaigner.db.{Campaigns, UpdateSupport}
-import com.advancedtelematic.campaigner.util.{ActorSpec, CampaignerSpec, DatabaseUpdateSpecUtil}
+import com.advancedtelematic.campaigner.db.{CampaignErrorsSupport, Campaigns, UpdateSupport}
+import com.advancedtelematic.campaigner.util.{ActorSpec, CampaignerSpec, DatabaseUpdateSpecUtil, FakeDirectorClient}
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Gen}
 
 import scala.concurrent.Future
 
-class CampaignSchedulerSpec extends ActorSpec[CampaignScheduler] with CampaignerSpec with UpdateSupport with DatabaseUpdateSpecUtil {
+class CampaignSchedulerSpec extends ActorSpec[CampaignScheduler] with CampaignerSpec with UpdateSupport with DatabaseUpdateSpecUtil with CampaignErrorsSupport {
   import Arbitrary._
   import CampaignScheduler._
 
@@ -28,7 +31,7 @@ class CampaignSchedulerSpec extends ActorSpec[CampaignScheduler] with Campaigner
   }
 
   "campaign scheduler" should "trigger updates for each group" in {
-    val groups   = arbitrary[NonEmptyList[GroupId]].sample.get
+    val groups   = NonEmptyList.fromListUnsafe(Gen.listOfN(3, genGroupId).sample.get)
     val campaign = createDbCampaignWithUpdate(maybeGroups = Some(groups)).futureValue
 
     val parent   = TestProbe()
@@ -36,54 +39,83 @@ class CampaignSchedulerSpec extends ActorSpec[CampaignScheduler] with Campaigner
     campaigns.scheduleGroups(campaign.id, groups).futureValue
     groups.map{ g => deviceRegistry.setGroup(g, arbitrary[Seq[DeviceId]].sample.get) }
 
-    parent.childActorOf(CampaignScheduler.props(
+    val child = parent.childActorOf(CampaignScheduler.props(
       deviceRegistry,
       director,
       campaign,
       schedulerDelay,
       schedulerBatchSize
     ))
-    parent.expectMsg(1.minute, CampaignComplete(campaign.id))
 
-    deviceRegistry.allGroups() shouldBe groups.toList.toSet
+    parent.expectMsg(10.seconds, CampaignSchedulingComplete(campaign.id))
+
+    child ! PoisonPill
   }
 
   "PRO-3672: campaign with 0 affected devices" should "yield a `finished` status" in {
-    val groups   = arbitrary[NonEmptyList[GroupId]].sample.get
+    val groups   = NonEmptyList.fromListUnsafe(Gen.listOfN(3, genGroupId).sample.get)
     val campaign = createDbCampaignWithUpdate(maybeGroups = Some(groups)).futureValue
     val parent   = TestProbe()
 
-    val director = new DirectorClient {
-      override def setMultiUpdateTarget(
-        ns: Namespace,
-        update: ExternalUpdateId,
-        devices: Seq[DeviceId]
-      ): Future[Seq[DeviceId]] = FastFuture.successful(Seq.empty)
-
-      override def cancelUpdate(
-        ns: Namespace,
-        devs: Seq[DeviceId]
-      ): Future[Seq[DeviceId]] = FastFuture.successful(Seq.empty)
-
-      override def cancelUpdate(
-        ns: Namespace,
-        device: DeviceId): Future[Unit] = FastFuture.successful(())
-
-      override def findAffected(ns: Namespace, updateId: ExternalUpdateId, devices: Seq[DeviceId]): Future[Seq[DeviceId]] =
-        Future.successful(Seq.empty)
-    }
-
     campaigns.scheduleGroups(campaign.id, groups).futureValue
 
-    parent.childActorOf(CampaignScheduler.props(
+    val child = parent.childActorOf(CampaignScheduler.props(
       deviceRegistry,
-      director,
+      new FakeDirectorClient,
       campaign,
       schedulerDelay,
       schedulerBatchSize
     ))
-    parent.expectMsg(20.seconds, CampaignComplete(campaign.id))
+
+    parent.expectMsg(5.seconds, CampaignSchedulingComplete(campaign.id))
+
+    child ! PoisonPill
 
     campaigns.campaignStats(campaign.id).futureValue.status shouldBe CampaignStatus.finished
+  }
+
+  it should "try again if campaign fails" in {
+    val failingDirector = new DirectorClient {
+      var fails = new AtomicInteger(0)
+
+      override def setMultiUpdateTarget(ns: Namespace, updateId: ExternalUpdateId, devices: Seq[DeviceId]): Future[Seq[DeviceId]] = {
+        if(fails.incrementAndGet() >= 3)
+          FastFuture.successful(devices)
+        else
+          throw new RuntimeException("[test] setMultiUpdateTarget failing director")
+      }
+
+      override def findAffected(ns: Namespace, updateId: ExternalUpdateId, devices: Seq[DeviceId]): Future[Seq[DeviceId]] =
+        throw new RuntimeException("[test] findAffected failing director")
+
+      override def cancelUpdate(ns: Namespace, devices: Seq[DeviceId]): Future[Seq[DeviceId]] = ???
+
+      override def cancelUpdate(ns: Namespace, device: DeviceId): Future[Unit] = ???
+    }
+
+    val groups   = NonEmptyList.fromListUnsafe(Gen.listOfN(1, genGroupId).sample.get)
+    val campaign = createDbCampaignWithUpdate(maybeGroups = Some(groups)).futureValue
+
+    campaigns.scheduleGroups(campaign.id, groups).futureValue
+    groups.map{ g => deviceRegistry.setGroup(g, arbitrary[Seq[DeviceId]].sample.get) }
+
+    val parent   = TestProbe()
+
+    val child = parent.childActorOf(CampaignScheduler.props(
+      deviceRegistry,
+      failingDirector,
+      campaign,
+      schedulerDelay,
+      schedulerBatchSize
+    ))
+
+    parent.expectMsg(5.seconds, CampaignSchedulingComplete(campaign.id))
+
+    child ! PoisonPill
+
+    val campaignErrors = campaignErrorsRepo.find(campaign.id).futureValue.head
+
+    campaignErrors.errorCount shouldBe 2
+    campaignErrors.lastError shouldBe "[test] setMultiUpdateTarget failing director"
   }
 }

--- a/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
@@ -1,25 +1,24 @@
 package com.advancedtelematic.campaigner.actor
 
-import akka.http.scaladsl.util.FastFuture
+import akka.actor.{PoisonPill, Terminated}
 import akka.testkit.TestProbe
 import cats.data.NonEmptyList
-import com.advancedtelematic.campaigner.client._
+import com.advancedtelematic.campaigner.actor.CampaignScheduler.CampaignSchedulingComplete
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
-import com.advancedtelematic.campaigner.db.{Campaigns, UpdateSupport}
+import com.advancedtelematic.campaigner.db.{CampaignErrorsSupport, Campaigns, UpdateSupport}
 import com.advancedtelematic.campaigner.util.{ActorSpec, CampaignerSpec}
-import com.advancedtelematic.libats.data.DataType.Namespace
-import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
+import org.scalatest.BeforeAndAfterEach
 
+import scala.async.Async._
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class CampaignSupervisorSpec extends ActorSpec[CampaignSupervisor] with CampaignerSpec with UpdateSupport {
+class CampaignSupervisorSpec extends ActorSpec[CampaignSupervisor] with BeforeAndAfterEach with CampaignerSpec with UpdateSupport with CampaignErrorsSupport {
 
-  import CampaignScheduler._
   import CampaignSupervisor._
+  import org.scalacheck.Arbitrary._
 
   val campaigns = Campaigns()
 
@@ -37,10 +36,9 @@ class CampaignSupervisorSpec extends ActorSpec[CampaignSupervisor] with Campaign
 
     campaigns.create(campaign1, group, Seq.empty).futureValue
     campaigns.create(campaign2, group, Seq.empty).futureValue
-
     campaigns.scheduleGroups(campaign1.id, group).futureValue
 
-    parent.childActorOf(CampaignSupervisor.props(
+    val child = parent.childActorOf(CampaignSupervisor.props(
       deviceRegistry,
       director,
       schedulerPollingTimeout,
@@ -49,58 +47,67 @@ class CampaignSupervisorSpec extends ActorSpec[CampaignSupervisor] with Campaign
     ))
 
     parent.expectMsg(3.seconds, CampaignsScheduled(Set(campaign1.id)))
-    parent.expectMsg(3.seconds, CampaignComplete(campaign1.id))
+    parent.expectMsg(3.seconds, CampaignSchedulingComplete(campaign1.id))
 
     campaigns.scheduleGroups(campaign2.id, group).futureValue
 
     parent.expectMsg(3.seconds, CampaignsScheduled(Set(campaign2.id)))
+    parent.expectMsg(3.seconds, CampaignSchedulingComplete(campaign2.id))
+
+    child ! PoisonPill
   }
 
-}
+  it should "campaigns with enough errors" in {
+    val campaign = buildCampaignWithUpdate
+    val group    = NonEmptyList.one(GroupId.generate)
+    val parent   = TestProbe()
 
-class CampaignSupervisorSpec2 extends ActorSpec[CampaignSupervisor] with CampaignerSpec with UpdateSupport {
+    async {
+      await(campaigns.create(campaign, group, Seq.empty))
+      await(campaigns.scheduleGroups(campaign.id, group))
+      val errorsF = (0 to CampaignScheduler.MAX_CAMPAIGN_ERROR_COUNT).map(i => campaignErrorsRepo.addError(campaign.id, s"Some error $i"))
+      await(Future.sequence(errorsF))
+    }.futureValue
 
-  import CampaignSupervisor._
-  import org.scalacheck.Arbitrary._
+    val child = parent.childActorOf(CampaignSupervisor.props(
+      deviceRegistry,
+      director,
+      schedulerPollingTimeout,
+      10.seconds,
+      schedulerBatchSize
+    ), "CampaignSupervisorIgnoreErrors")
 
-  val campaigns = Campaigns()
+    parent.expectNoMessage(3.seconds)
 
-  def buildCampaignWithUpdate: Campaign = {
-    val update = genMultiTargetUpdate.sample.get
-    val updateId = updateRepo.persist(update).futureValue
-    arbitrary[Campaign].sample.get.copy(updateId = updateId)
+    child ! PoisonPill
   }
 
-  "campaign supervisor" should "clean out campaigns that are marked to be cancelled" in {
+  it should "clean out campaigns that are marked to be cancelled" in {
     val campaign = buildCampaignWithUpdate
     val group    = NonEmptyList.one(GroupId.generate)
     val parent   = TestProbe()
     val n        = Gen.choose(batch, batch * 2).sample.get
     val devs     = Gen.listOfN(n, genDeviceId).sample.get
-    val registry = new DeviceRegistryClient {
-      override def devicesInGroup(_ns: Namespace,
-                                  _grp: GroupId,
-                                  offset: Long,
-                                  limit: Long): Future[Seq[DeviceId]] =
-        FastFuture.successful(devs.drop(offset.toInt).take(limit.toInt))
-    }
+
+    deviceRegistry.setGroup(group.head, devs)
 
     campaigns.create(campaign, group, Seq.empty).futureValue
-    campaigns.scheduleGroups(campaign.id, group)
+    campaigns.scheduleGroups(campaign.id, group).futureValue
 
-    parent.childActorOf(CampaignSupervisor.props(
-      registry,
+    val child = parent.childActorOf(CampaignSupervisor.props(
+      deviceRegistry,
       director,
       schedulerPollingTimeout,
       10.seconds,
       schedulerBatchSize
-    ))
+    ), "CampaignSupervisorCancel")
+
     parent.expectMsg(5.seconds, CampaignsScheduled(Set(campaign.id)))
-    expectNoMessage(5.seconds)
 
     campaigns.cancel(campaign.id).futureValue
-    parent.expectMsg(5.seconds, CampaignsCancelled(Set(campaign.id)))
-    expectNoMessage(5.seconds)
-  }
 
+    parent.expectMsg(5.seconds, CampaignsCancelled(Set(campaign.id)))
+
+    child ! PoisonPill
+  }
 }


### PR DESCRIPTION
Retry campaign when campaign fails

Do not retry if campaign failed too many times


This is an interim solution for OTA-848 while we cannot add more
states to not change the api for frontend.

We store the errors in a db table and use that to track how many
errors occurred and whether a campaign already failed too many times,
so it's not picked up by the scheduler again.

The actor system hierarchy had to be changed again... tbh I think this
should just be rewritten from scratch.