### PR TITLE
Implement creating and listing child campaigns

### DIFF
--- a/src/main/resources/db/migration/V11__add_parent_campaign_column.sql
+++ b/src/main/resources/db/migration/V11__add_parent_campaign_column.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `campaigns` ADD COLUMN `parent_campaign_uuid` char(36) NULL
+;
+
+ALTER TABLE `campaigns` ADD CONSTRAINT fk_parent_campaign_uuid FOREIGN KEY (parent_campaign_uuid) REFERENCES campaigns(uuid)
+;

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -30,9 +30,10 @@ object DataType {
     status: CampaignStatus,
     createdAt: Instant,
     updatedAt: Instant,
+    parentCampaignId: Option[CampaignId],
     autoAccept: Boolean = true
   )
-  
+
   final case class ExternalUpdateId(value: String) extends AnyVal
 
   final case class UpdateSource(id: ExternalUpdateId, sourceType: UpdateType)
@@ -61,6 +62,7 @@ object DataType {
   final case class CreateCampaign(name: String,
                                   update: UpdateId,
                                   groups: NonEmptyList[GroupId],
+                                  parentCampaignId: Option[CampaignId],
                                   metadata: Option[Seq[CreateCampaignMetadata]] = None,
                                   approvalNeeded: Option[Boolean] = Some(false))
   {
@@ -73,6 +75,7 @@ object DataType {
         CampaignStatus.prepared,
         Instant.now(),
         Instant.now(),
+        parentCampaignId,
         !approvalNeeded.getOrElse(false)
       )
     }
@@ -90,6 +93,7 @@ object DataType {
     status: CampaignStatus,
     createdAt: Instant,
     updatedAt: Instant,
+    parentCampaignId: Option[CampaignId],
     groups: Set[GroupId],
     metadata: Seq[CreateCampaignMetadata],
     autoAccept: Boolean
@@ -105,6 +109,7 @@ object DataType {
         c.status,
         c.createdAt,
         c.updatedAt,
+        c.parentCampaignId,
         groups,
         metadata.map(m => CreateCampaignMetadata(m.`type`, m.value)),
         c.autoAccept

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -94,13 +94,14 @@ object DataType {
     createdAt: Instant,
     updatedAt: Instant,
     parentCampaignId: Option[CampaignId],
+    childCampaignIds: Set[CampaignId],
     groups: Set[GroupId],
     metadata: Seq[CreateCampaignMetadata],
     autoAccept: Boolean
   )
 
   object GetCampaign {
-    def apply(c: Campaign, groups: Set[GroupId], metadata: Seq[CampaignMetadata]): GetCampaign =
+    def apply(c: Campaign, childCampaignIds: Set[CampaignId], groups: Set[GroupId], metadata: Seq[CampaignMetadata]): GetCampaign =
       GetCampaign(
         c.namespace,
         c.id,
@@ -110,6 +111,7 @@ object DataType {
         c.createdAt,
         c.updatedAt,
         c.parentCampaignId,
+        childCampaignIds,
         groups,
         metadata.map(m => CreateCampaignMetadata(m.`type`, m.value)),
         c.autoAccept

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.campaigner.data.DataType.GroupStatus.GroupStatus
 import com.advancedtelematic.campaigner.data.DataType.SortBy.SortBy
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.db.SlickMapping._
-import com.advancedtelematic.campaigner.http.Errors
+import com.advancedtelematic.campaigner.http.Errors._
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.PaginationResult
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
@@ -150,7 +150,7 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
       .findAction(campaignId)
       .andThen(groupStatsRepo.persistManyAction(campaignId, groups))
       .transactionally
-      .handleIntegrityErrors(Errors.CampaignAlreadyLaunched)
+      .handleIntegrityErrors(CampaignAlreadyLaunched)
 
   def scheduleGroups(campaign: CampaignId, groups: NonEmptyList[GroupId]): Future[Unit] =
     db.run(scheduleGroupsAction(campaign, groups.toList.toSet))
@@ -208,7 +208,7 @@ protected [db] class CampaignStatusTransition(implicit db: Database, ec: Executi
 
   private def progressGroupAction(campaignId: CampaignId, group: GroupId, status: GroupStatus, stats: Stats): DBIO[Unit] =
     if (stats.affected > stats.processed)
-      DBIO.failed(Errors.InvalidCounts)
+      DBIO.failed(InvalidCounts)
     else
       groupStatsRepo.updateGroupStatsAction(campaignId, group, status, stats)
 

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -109,9 +109,10 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
 
   def findClientCampaign(campaignId: CampaignId): Future[GetCampaign] = for {
     c <- campaignRepo.find(campaignId)
+    childIds <- campaignRepo.findChildIdsOf(campaignId)
     groups <- db.run(findGroupsAction(c.id))
     metadata <- campaignMetadataRepo.findFor(campaignId)
-  } yield GetCampaign(c, groups, metadata)
+  } yield GetCampaign(c, childIds, groups, metadata)
 
   def findCampaignsByUpdate(update: UpdateId): Future[Seq[Campaign]] =
     db.run(campaignRepo.findByUpdateAction(update))

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Errors.scala
@@ -1,0 +1,17 @@
+package com.advancedtelematic.campaigner.db
+
+import java.sql.SQLIntegrityConstraintViolationException
+
+object Errors {
+
+  object UpdateFKViolation {
+    def unapply(e: SQLIntegrityConstraintViolationException): Boolean =
+      e.getErrorCode == 1452 && e.getMessage.contains("update_fk")
+  }
+
+  object CampaignFKViolation {
+    def unapply(e: SQLIntegrityConstraintViolationException): Boolean =
+      e.getErrorCode == 1452 && e.getMessage.contains("fk_parent_campaign_uuid")
+  }
+
+}

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
@@ -250,6 +250,16 @@ protected class CampaignRepository()(implicit db: Database, ec: ExecutionContext
   def setStatusAction(campaignId: CampaignId, status: CampaignStatus): DBIO[CampaignId] =
     Schema.campaigns
       .filter(_.id === campaignId).map(_.status).update(status).map(_ => campaignId)
+
+  def findChildIdsOf(parentId: CampaignId): Future[Set[CampaignId]] = {
+    db.run {
+      Schema.campaigns
+        .filter(_.parentCampaignId === parentId)
+        .map(_.id)
+        .result
+        .map(_.toSet)
+    }
+  }
 }
 
 

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -29,10 +29,11 @@ object Schema {
     def autoAccept = column[Boolean]   ("auto_accept")
     def createdAt = column[Instant]   ("created_at")
     def updatedAt = column[Instant]   ("updated_at")
+    def parentCampaignId = column[Option[CampaignId]]("parent_campaign_uuid")
 
     def updateForeignKey = foreignKey("update_fk", update, updates)(_.uuid)
 
-    override def * = (namespace, id, name, update, status, createdAt, updatedAt, autoAccept) <>
+    override def * = (namespace, id, name, update, status, createdAt, updatedAt, parentCampaignId, autoAccept) <>
       ((Campaign.apply _).tupled, Campaign.unapply)
   }
 

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -3,12 +3,13 @@ package com.advancedtelematic.campaigner.http
 import akka.http.scaladsl.model.StatusCodes
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.libats.data.ErrorCode
-import com.advancedtelematic.libats.http.Errors.{MissingEntity, RawError, Error}
+import com.advancedtelematic.libats.http.Errors.{Error, MissingEntity, RawError}
 import com.advancedtelematic.libats.messaging_datatype.DataType.UpdateId
 
 object ErrorCodes {
   val ConflictingCampaign = ErrorCode("campaign_already_exists")
   val MissingUpdateSource = ErrorCode("missing_update_source")
+  val MissingParentCampaign = ErrorCode("missing_parent_campaign")
   val MissingUpdate = ErrorCode("missing_update")
   val ConflictingMetadata = ErrorCode("campaign_metadata_already_exists")
   val CampaignAlreadyLaunched = ErrorCode("campaign_already_launched")
@@ -30,6 +31,12 @@ object Errors {
     ErrorCodes.MissingUpdateSource,
     StatusCodes.PreconditionFailed,
     "The update associated with the given campaign does not exist."
+  )
+
+  val MissingParentCampaign = RawError(
+    ErrorCodes.MissingParentCampaign,
+    StatusCodes.PreconditionFailed,
+    "The parent campaign for this retry campaign is invalid or does not exist."
   )
 
   val ConflictingCampaign = RawError(ErrorCodes.ConflictingCampaign, StatusCodes.Conflict, "campaign already exists")

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -34,14 +34,16 @@ object Generators {
     update <- arbitrary[UpdateId]
     ca      = Instant.now()
     ua      = Instant.now()
-  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, ca, ua)
+    parent  = None
+  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, ca, ua, parent)
 
   def genCreateCampaign(genName: Gen[String] = arbitrary[String]): Gen[CreateCampaign] = for {
     n   <- genName
     update <- arbitrary[UpdateId]
     gs <- arbitrary[NonEmptyList[GroupId]]
     meta   <- Gen.option(genCampaignMetadata.map(List(_)))
-  } yield CreateCampaign(n, update, gs, meta)
+    parent = None
+  } yield CreateCampaign(n, update, gs, parent, meta)
 
   val genUpdateCampaign: Gen[UpdateCampaign] = for {
     n   <- arbitrary[String].suchThat(!_.isEmpty)

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -103,7 +103,7 @@ class CampaignResourceSpec
 
     And("the parent campaign should have the child campaing in child campaings list")
     val parentCampaign = getCampaignOk(parentId)
-    parentCampaign.childCampaignIds should (contain(childId))
+    parentCampaign.childCampaignIds should contain(childId)
   }
 
   "POST /campaigns" should "fail if parent_campaign_id does not refer to an existing campaign" in {
@@ -123,9 +123,8 @@ class CampaignResourceSpec
       When("a child campaign is created")
       Then("a PreconditionFailed error is raised")
       createCampaign(createCampaignWithInvalidParentId) ~> routes ~> check {
-        // TODO: write a more proper check once
-        // https://github.com/advancedtelematic/libats/pull/91 is merged
         status shouldBe PreconditionFailed
+        responseAs[ErrorRepresentation].code shouldBe Errors.MissingParentCampaign.code
       }
   }
 


### PR DESCRIPTION
The PR is blocked on https://github.com/advancedtelematic/libats/pull/91 which is needed for returning a proper error when non-existing `parent_campaign_id` is given during campaign creation.