### PR TITLE
Implement creation of retry-campaigns.

### DIFF
--- a/src/main/resources/db/migration/V11__add_parent_campaign_column.sql
+++ b/src/main/resources/db/migration/V11__add_parent_campaign_column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `campaigns` ADD COLUMN `parent_campaign_uuid` CHAR(36) NULL DEFAULT NULL;
+
+ALTER TABLE `campaigns` ADD CONSTRAINT fk_parent_campaign_uuid FOREIGN KEY (parent_campaign_uuid) REFERENCES campaigns(uuid);

--- a/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
@@ -33,6 +33,9 @@ object Codecs {
   implicit val decoderCreateCampaign: Decoder[CreateCampaign] = deriveDecoder
   implicit val encoderCreateCampaign: Encoder[CreateCampaign] = deriveEncoder
 
+  implicit val decoderCreateRetryCampaign: Decoder[CreateRetryCampaign] = deriveDecoder
+  implicit val encoderCreateRetryCampaign: Encoder[CreateRetryCampaign] = deriveEncoder
+
   implicit val decoderCreateUpdate: Decoder[CreateUpdate] = deriveDecoder
   implicit val encoderCreateUpdate: Encoder[CreateUpdate] = deriveEncoder
 

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -30,6 +30,7 @@ object DataType {
     status: CampaignStatus,
     createdAt: Instant,
     updatedAt: Instant,
+    parentCampaignId: Option[CampaignId],
     autoAccept: Boolean = true
   )
   
@@ -62,7 +63,8 @@ object DataType {
                                   update: UpdateId,
                                   groups: NonEmptyList[GroupId],
                                   metadata: Option[Seq[CreateCampaignMetadata]] = None,
-                                  approvalNeeded: Option[Boolean] = Some(false))
+                                  approvalNeeded: Option[Boolean] = Some(false),
+                                  parentCampaignId: Option[CampaignId] = None)
   {
     def mkCampaign(ns: Namespace): Campaign = {
       Campaign(
@@ -73,6 +75,7 @@ object DataType {
         CampaignStatus.prepared,
         Instant.now(),
         Instant.now(),
+        parentCampaignId,
         !approvalNeeded.getOrElse(false)
       )
     }
@@ -81,6 +84,7 @@ object DataType {
       metadata.toList.flatten.map(_.toCampaignMetadata(campaignId))
   }
 
+  final case class CreateRetryCampaign(groupId: GroupId)
 
   final case class GetCampaign(
     namespace: Namespace,

--- a/src/main/scala/com/advancedtelematic/campaigner/db/DBErrors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/DBErrors.scala
@@ -1,0 +1,18 @@
+package com.advancedtelematic.campaigner.db
+
+import java.sql.SQLIntegrityConstraintViolationException
+
+object DBErrors {
+
+  object CampaignUpdateFKViolation {
+    def unapply(e: SQLIntegrityConstraintViolationException): Boolean =
+      e.getErrorCode == 1452 && e.getMessage.contains("update_fk")
+  }
+
+
+  object CampaignCampaignFKViolation {
+    def unapply(e: SQLIntegrityConstraintViolationException): Boolean =
+      e.getErrorCode == 1452 && e.getMessage.contains("fk_parent_campaign_uuid")
+  }
+
+}

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -29,10 +29,11 @@ object Schema {
     def autoAccept = column[Boolean]   ("auto_accept")
     def createdAt = column[Instant]   ("created_at")
     def updatedAt = column[Instant]   ("updated_at")
+    def parentCampaignId = column[Option[CampaignId]]("parent_campaign_uuid")
 
     def updateForeignKey = foreignKey("update_fk", update, updates)(_.uuid)
 
-    override def * = (namespace, id, name, update, status, createdAt, updatedAt, autoAccept) <>
+    override def * = (namespace, id, name, update, status, createdAt, updatedAt, parentCampaignId, autoAccept) <>
       ((Campaign.apply _).tupled, Campaign.unapply)
   }
 

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -3,12 +3,13 @@ package com.advancedtelematic.campaigner.http
 import akka.http.scaladsl.model.StatusCodes
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.libats.data.ErrorCode
-import com.advancedtelematic.libats.http.Errors.{MissingEntity, RawError, Error}
+import com.advancedtelematic.libats.http.Errors.{Error, MissingEntity, RawError}
 import com.advancedtelematic.libats.messaging_datatype.DataType.UpdateId
 
 object ErrorCodes {
   val ConflictingCampaign = ErrorCode("campaign_already_exists")
   val MissingUpdateSource = ErrorCode("missing_update_source")
+  val MissingParentCampaign = ErrorCode("missing_parent_campaign")
   val MissingUpdate = ErrorCode("missing_update")
   val ConflictingMetadata = ErrorCode("campaign_metadata_already_exists")
   val CampaignAlreadyLaunched = ErrorCode("campaign_already_launched")
@@ -30,6 +31,12 @@ object Errors {
     ErrorCodes.MissingUpdateSource,
     StatusCodes.PreconditionFailed,
     "The update associated with the given campaign does not exist."
+  )
+
+  val MissingParentCampaign = RawError(
+    ErrorCodes.MissingParentCampaign,
+    StatusCodes.PreconditionFailed,
+    "The parent campaign for this retry campaign is invalid or does not exist."
   )
 
   val ConflictingCampaign = RawError(ErrorCodes.ConflictingCampaign, StatusCodes.Conflict, "campaign already exists")

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -34,7 +34,7 @@ object Generators {
     update <- arbitrary[UpdateId]
     ca      = Instant.now()
     ua      = Instant.now()
-  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, ca, ua)
+  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, ca, ua, None)
 
   def genCreateCampaign(genName: Gen[String] = arbitrary[String]): Gen[CreateCampaign] = for {
     n   <- genName

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -48,8 +48,17 @@ trait ResourceSpec extends ScalatestRouteTest
   def createCampaign(request: CreateCampaign): HttpRequest =
     Post(apiUri("campaigns"), request).withHeaders(header)
 
+  def createRetryCampaign(parentCampaignId: CampaignId, request: CreateRetryCampaign): HttpRequest =
+    Post(apiUri(s"campaigns/${parentCampaignId.show}/campaigns"), request).withHeaders(header)
+
   def createCampaignOk(request: CreateCampaign): CampaignId =
     createCampaign(request) ~> routes ~> check {
+      status shouldBe Created
+      responseAs[CampaignId]
+    }
+
+  def createRetryCampaignOk(parentCampaignId: CampaignId, request: CreateRetryCampaign): CampaignId =
+    createRetryCampaign(parentCampaignId, request) ~> routes ~> check {
       status shouldBe Created
       responseAs[CampaignId]
     }


### PR DESCRIPTION
Maybe I'm beating a dead horse here, but yesterday @nkly and I realised about the implementation outline in OTA-2113 and I believe it would be better approach.
In particular the use of a new endpoint `POST /api/v2/campaigns/:campaignId/campaigns` would make life easier for the FE: they create a new group and only need that groupId to create the retry-campaign. The other way forces the FE to send the updateId and the name on top of the groupId. I think it also makes it easier to maintain integrity.
I just leave this here and let's discuss on Monday which way we should go.