### PR TITLE
[OTA-2194] Change the /campaigns endpoint to return campaigns instead of IDs

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -124,7 +124,7 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
         CampaignStatus.values.map(s => s -> counts.getOrElse(s, 0)).toMap
       }
 
-  def allCampaigns(ns: Namespace, sortBy: SortBy, offset: Long, limit: Long, status: Option[CampaignStatus], nameContains: Option[String]): Future[PaginationResult[CampaignId]] =
+  def allCampaigns(ns: Namespace, sortBy: SortBy, offset: Long, limit: Long, status: Option[CampaignStatus], nameContains: Option[String]): Future[PaginationResult[Campaign]] =
     campaignRepo.all(ns, sortBy, offset, limit, status, nameContains)
 
   def findNamespaceCampaign(ns: Namespace, campaignId: CampaignId): Future[Campaign] =

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
@@ -174,7 +174,7 @@ protected class CampaignRepository()(implicit db: Database, ec: ExecutionContext
   def find(campaign: CampaignId, ns: Option[Namespace] = None): Future[Campaign] =
     db.run(findAction(campaign, ns))
 
-  def all(ns: Namespace, sortBy: SortBy, offset: Long, limit: Long, status: Option[CampaignStatus], nameContains: Option[String]): Future[PaginationResult[CampaignId]] = {
+  def all(ns: Namespace, sortBy: SortBy, offset: Long, limit: Long, status: Option[CampaignStatus], nameContains: Option[String]): Future[PaginationResult[Campaign]] = {
     db.run {
       Schema.campaigns
         .filter(_.namespace === ns)
@@ -182,7 +182,6 @@ protected class CampaignRepository()(implicit db: Database, ec: ExecutionContext
         .maybeFilter(_.status === status)
         .maybeContains(_.name, nameContains)
         .sortBy(sortBy)
-        .map(_.id)
         .paginateResult(offset, limit)
     }
   }

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -292,20 +292,20 @@ class CampaignResourceSpec
     getCampaignsOk(CampaignStatus.launched.some).values shouldNot contain(id)
   }
 
-  "GET all campaigns" should "get all campaigns sorted by name when no sorting is given" in {
+  "GET all campaigns sorted by name" should "get all campaigns sorted alphabetically by name" in {
     val requests = Gen.listOfN(10, genCreateCampaign(Gen.alphaNumStr.retryUntil(_.nonEmpty))).generate
     val sortedNames = requests.map(_.name).sortBy(_.toLowerCase)
     requests.map(createCampaignWithUpdateOk(_))
 
-    val campaignNames = getCampaignsOk().values.map(getCampaignOk).map(_.name).filter(sortedNames.contains)
+    val campaignNames = getCampaignsOk(sortBy = Some(SortBy.Name)).values.map(getCampaignOk).map(_.name).filter(sortedNames.contains)
     campaignNames shouldBe sortedNames
   }
 
-  "GET all campaigns sorted by creation time" should "sort the campaigns from newest to oldest" in {
+  "GET all campaigns" should "get all campaigns sorted from newest to oldest when no sorting is given" in {
     val requests = Gen.listOfN(10, genCreateCampaign()).generate
     requests.map(createCampaignWithUpdateOk(_))
 
-    val campaignsNewestToOldest = getCampaignsOk(sortBy = Some(SortBy.CreatedAt)).values.map(getCampaignOk)
+    val campaignsNewestToOldest = getCampaignsOk().values.map(getCampaignOk)
     campaignsNewestToOldest.reverse.map(_.createdAt) shouldBe sorted
   }
 

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -77,7 +77,7 @@ trait ResourceSpec extends ScalatestRouteTest
 
     Get(apiUri("campaigns").withQuery(Query(m))).withHeaders(header) ~> routes ~> check {
       status shouldBe OK
-      responseAs[PaginationResult[CampaignId]]
+      responseAs[PaginationResult[Campaign]].map(_.id)
     }
   }
 


### PR DESCRIPTION
Change the `/campaigns` endpoint so that:

- It return campaigns instead of campaign IDs.
- It sorts the campaigns from newest to oldest created by default.

*Note* Should be merged together with related FE changes, else campaigns will stop showing in the UI.