### PR TITLE
(OTA-2255) Take cancelled devices into account when calculating campaign status

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -233,7 +233,7 @@ protected [db] class CampaignStatusTransition(implicit db: Database, ec: Executi
     val countFinishedDevices =
       Schema.deviceUpdates
         .filter(_.campaignId === campaign).map(_.status)
-        .filter(status => status === DeviceStatus.successful || status === DeviceStatus.failed)
+        .filter(status => status === DeviceStatus.successful || status === DeviceStatus.failed || status === DeviceStatus.cancelled)
         .length.result
 
     for {

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -1,6 +1,7 @@
 package com.advancedtelematic.campaigner.http
 
 import akka.http.scaladsl.model.StatusCodes._
+import cats.data.NonEmptyList
 import cats.syntax.either._
 import cats.syntax.option._
 import cats.syntax.show._
@@ -354,4 +355,40 @@ class CampaignResourceSpec
     }
   }
 
+  "GET /campaigns/:id/stats" should "return correct statistics" in {
+    val campaigns = Campaigns()
+    val groupId = genGroupId.generate
+
+    val successDevices = Gen.listOf(genDeviceId).generate
+    val failedDevices = Gen.listOf(genDeviceId).generate
+    val cancelledDevices = Gen.listOf(genDeviceId).generate
+    val affectedDevices = successDevices ++ failedDevices ++ cancelledDevices
+    val notAffectedCount = Gen.choose(0, 5).generate
+    val affectedCount = affectedDevices.size
+    val processedCount = affectedCount + notAffectedCount
+
+    Given("a main campaign")
+    val (mainCampaignId, mainCampaign) = createCampaignWithUpdateOk(
+      genCreateCampaign().map(_.copy(groups = NonEmptyList.one(groupId)))
+    )
+    campaigns.launch(mainCampaignId).futureValue
+    campaigns.completeGroup(mainCampaignId, groupId, Stats(processedCount, affectedCount)).futureValue
+    campaigns.scheduleDevices(mainCampaignId, mainCampaign.update, affectedDevices:_*).futureValue
+    campaigns.finishDevices(mainCampaignId, cancelledDevices, DeviceStatus.cancelled).futureValue
+    campaigns.finishDevices(mainCampaignId, failedDevices, DeviceStatus.failed).futureValue
+    campaigns.finishDevices(mainCampaignId, successDevices, DeviceStatus.successful).futureValue
+
+    When("requesting the stats")
+    Get(apiUri(s"campaigns/${mainCampaignId.show}/stats")).withHeaders(header) ~> routes ~> check {
+      status shouldBe OK
+
+      Then("the stats should be correct")
+      val campaignStats = responseAs[CampaignStats]
+      campaignStats.status shouldBe CampaignStatus.finished
+      campaignStats.finished shouldBe (successDevices.size + failedDevices.size)
+      campaignStats.failed should contain theSameElementsAs(failedDevices)
+      campaignStats.cancelled shouldBe cancelledDevices.size
+      campaignStats.stats(groupId) shouldBe Stats(processedCount, affectedCount)
+    }
+  }
 }


### PR DESCRIPTION
Fixes OTA-2255

Previously, when a device is individually cancelled, it is not taken
into account when calculating the campaign status, thus leaving the
campaign in 'launched' state indefinitely (`N_finished` is always
less than `N_affected`, and `N_cancelled` does not take individually
cancelled devices into account, see `CampaignStatusTransition#calculateCampaignStatus` method). Now such devices are counted as 'finished', thus allowing the campaign to
progress towards 'finished' state. When the whole campaign is cancelled,
however, it will end up in 'cancelled' states as it was before.

Signed-off-by: Nikolai Obedin <nikolai.obedin@here.com>