### PR TITLE
[OTA-2253] Create failure groups in dev-reg when receiving installation results.

### DIFF
--- a/src/main/resources/db/migration/V12__new_table_failed_groups.sql
+++ b/src/main/resources/db/migration/V12__new_table_failed_groups.sql
@@ -1,0 +1,8 @@
+CREATE TABLE failed_groups (
+  campaign_id  CHAR(36) NOT NULL,
+  group_id     CHAR(36) NOT NULL,
+  failure_code VARCHAR(200) NOT NULL,
+
+  CONSTRAINT pk_failed_groups PRIMARY KEY (campaign_id, failure_code),
+  CONSTRAINT fk_failed_groups_campaign_id FOREIGN KEY (campaign_id) REFERENCES campaigns (uuid)
+);

--- a/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
@@ -43,7 +43,7 @@ object DaemonBoot extends BootApp
     "campaign-supervisor"
   )
 
-  startListener[DeviceInstallationReport](new DeviceInstallationReportListener())
+  startListener[DeviceInstallationReport](new DeviceInstallationReportListener(deviceRegistry))
   startListener[DeviceEventMessage](new DeviceEventListener(director))
 
   val routes: Route = (versionHeaders(version) & logResponseMetrics(projectName)) {

--- a/src/main/scala/com/advancedtelematic/campaigner/daemon/DeviceInstallationReportListener.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/daemon/DeviceInstallationReportListener.scala
@@ -1,17 +1,20 @@
 package com.advancedtelematic.campaigner.daemon
 
+import akka.http.scaladsl.util.FastFuture
 import cats.syntax.show._
+import com.advancedtelematic.campaigner.client.DeviceRegistryClient
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.db.{Campaigns, UpdateSupport}
 import com.advancedtelematic.campaigner.http.Errors
-import com.advancedtelematic.libats.data.DataType.{CampaignId => CampaignCorrelationId, MultiTargetUpdateId}
+import com.advancedtelematic.libats.data.DataType.{MultiTargetUpdateId, Namespace, CampaignId => CampaignCorrelationId}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceInstallationReport
 import org.slf4j.LoggerFactory
 import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DeviceInstallationReportListener()(implicit db: Database, ec: ExecutionContext)
+class DeviceInstallationReportListener(deviceRegistryClient: DeviceRegistryClient)(implicit db: Database, ec: ExecutionContext)
   extends (DeviceInstallationReport => Future[Unit]) with UpdateSupport {
 
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
@@ -19,14 +22,19 @@ class DeviceInstallationReportListener()(implicit db: Database, ec: ExecutionCon
   val campaigns = Campaigns()
 
   def apply(msg: DeviceInstallationReport): Future[Unit] = {
-    val resultStatus = if (msg.result.success)
-      DeviceStatus.successful
-    else
-      DeviceStatus.failed
+    val success = msg.result.success
+    val resultStatus = if (success) DeviceStatus.successful else DeviceStatus.failed
 
     val f = msg.correlationId match {
       case CampaignCorrelationId(uuid) =>
-        campaigns.finishDevices(CampaignId(uuid), Seq(msg.device), resultStatus)
+        val campaignId = CampaignId(uuid)
+        val addDeviceToFailedDeviceGroupFuture =
+          addDeviceToFailedDeviceGroup(msg.namespace, campaignId, msg.result.code, msg.device)
+        for {
+          _ <- campaigns.finishDevices(CampaignId(uuid), Seq(msg.device), resultStatus)
+          isMainCampaign <- campaigns.findClientCampaign(campaignId).map(_.parentCampaignId.isEmpty)
+          _ <- if (isMainCampaign && !success) addDeviceToFailedDeviceGroupFuture else Future.unit
+        } yield ()
       case MultiTargetUpdateId(uuid) => for {
         update <- updateRepo.findByExternalId(msg.namespace, ExternalUpdateId(uuid.toString))
         _ <- campaigns.finishDevice(update.uuid, msg.device, resultStatus)
@@ -40,4 +48,19 @@ class DeviceInstallationReportListener()(implicit db: Database, ec: ExecutionCon
         _log.info(s"Got DeviceUpdateReport for device ${msg.device.show} which is not scheduled by campaigner, ignoring this message.")
     }
   }
+
+  private def addDeviceToFailedDeviceGroup(ns: Namespace, campaignId: CampaignId, failureCode: String, deviceId: DeviceId): Future[Unit] =
+    findOrCreateFailedDeviceGroup(ns, campaignId, failureCode)
+      .flatMap(gid => deviceRegistryClient.addDeviceToGroup(ns, gid, deviceId))
+
+  private def findOrCreateFailedDeviceGroup(ns: Namespace, campaignId: CampaignId, failureCode: String): Future[GroupId] =
+    campaigns.fetchFailedGroupId(campaignId, failureCode).flatMap {
+      case Some(g) =>
+        FastFuture.successful(g)
+      case None =>
+        deviceRegistryClient
+          .createGroup(ns, s"failed-group-campaignId-$campaignId-failureCode-$failureCode")
+          .flatMap(gid => campaigns.persistFailedGroup(campaignId, gid, failureCode))
+    }
+
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -151,6 +151,8 @@ object DataType {
     status: CancelTaskStatus
   )
 
+  final case class FailedGroup(campaignId: CampaignId, groupId: GroupId, failureCode: String)
+
   object SortBy {
     sealed trait SortBy
     case object Name      extends SortBy

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -130,4 +130,16 @@ object Schema {
   }
   protected [db] val updates = TableQuery[UpdatesTable]
 
+  class FailedGroupsTable(tag: Tag) extends Table[FailedGroup](tag, "failed_groups") {
+    def campaignId = column[CampaignId]("campaign_id")
+    def groupId = column[GroupId]("group_id")
+    def failureCode = column[String]("failure_code")
+
+    def * = (campaignId, groupId, failureCode) <> ((FailedGroup.apply _).tupled, FailedGroup.unapply)
+
+    def pk = primaryKey("pk_failed_groups", (campaignId, failureCode))
+  }
+
+  protected[db] val failedGroups = TableQuery[FailedGroupsTable]
+
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/http/DeviceCampaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/DeviceCampaigns.scala
@@ -1,6 +1,5 @@
 package com.advancedtelematic.campaigner.http
 
-import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
 import cats.data.NonEmptyList
 import com.advancedtelematic.campaigner.client.{ExternalUpdate, ResolverClient, UserProfileClient}

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -11,6 +11,7 @@ object ErrorCodes {
   val MissingUpdateSource = ErrorCode("missing_update_source")
   val MissingParentCampaign = ErrorCode("missing_parent_campaign")
   val MissingUpdate = ErrorCode("missing_update")
+  val MissingFailedGroup = ErrorCode("missing_failed_group")
   val ConflictingMetadata = ErrorCode("campaign_metadata_already_exists")
   val CampaignAlreadyLaunched = ErrorCode("campaign_already_launched")
   val InvalidCounts = ErrorCode("invalid_stats_count")
@@ -37,6 +38,12 @@ object Errors {
     ErrorCodes.MissingParentCampaign,
     StatusCodes.PreconditionFailed,
     "The parent campaign for this retry campaign is invalid or does not exist."
+  )
+
+  val MissingFailedGroup = RawError(
+    ErrorCodes.MissingFailedGroup,
+    StatusCodes.PreconditionFailed,
+    "There is no failed device group for the given campaign and failure code."
   )
 
   val ConflictingCampaign = RawError(ErrorCodes.ConflictingCampaign, StatusCodes.Conflict, "campaign already exists")

--- a/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
@@ -83,6 +83,10 @@ class CampaignSupervisorSpec2 extends ActorSpec[CampaignSupervisor] with Campaig
                                   offset: Long,
                                   limit: Long): Future[Seq[DeviceId]] =
         FastFuture.successful(devs.drop(offset.toInt).take(limit.toInt))
+
+      override def createGroup(ns: Namespace, name: String): Future[GroupId] = ???
+
+      override def addDeviceToGroup(ns: Namespace, groupId: GroupId, deviceId: DeviceId): Future[Unit] = ???
     }
 
     campaigns.create(campaign, group, Seq.empty).futureValue

--- a/src/test/scala/com/advancedtelematic/campaigner/util/FakeClients.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/FakeClients.scala
@@ -74,6 +74,16 @@ class FakeDeviceRegistry extends DeviceRegistryClient {
   override def devicesInGroup(namespace: Namespace, groupId: GroupId, offset: Long, limit: Long): Future[Seq[DeviceId]] = Future.successful {
     allGroupDevices(groupId).slice(offset.toInt, (offset + limit).toInt)
   }
+
+  override def createGroup(ns: Namespace, name: String): Future[GroupId] = {
+    val groupId = GroupId.generate()
+    groups.put(groupId, Set())
+    Future.successful(groupId)
+  }
+
+  override def addDeviceToGroup(ns: Namespace, groupId: GroupId, deviceId: DeviceId): Future[Unit] = Future.successful {
+    groups.put(groupId, groups.get(groupId) + deviceId)
+  }
 }
 
 class SlowFakeDeviceRegistry extends FakeDeviceRegistry {


### PR DESCRIPTION
When implementing retry campaigns, we need some way to keep track of the group of failed devices that are associated with each retry campaign. This is the solution we thought of with @nkly.