### PR TITLE
[OTA-2270] New endpoint to retry devices failed with a failure group.

### DIFF
--- a/src/main/resources/db/migration/V12__new_table_failed_groups.sql
+++ b/src/main/resources/db/migration/V12__new_table_failed_groups.sql
@@ -1,0 +1,8 @@
+CREATE TABLE failed_groups (
+  campaign_id  CHAR(36) NOT NULL,
+  group_id     CHAR(36) NOT NULL,
+  failure_code VARCHAR(200) NOT NULL,
+
+  CONSTRAINT pk_failed_groups PRIMARY KEY (campaign_id, failure_code),
+  CONSTRAINT fk_failed_groups_campaign_id FOREIGN KEY (campaign_id) REFERENCES campaigns (uuid)
+);

--- a/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
@@ -43,7 +43,7 @@ object DaemonBoot extends BootApp
     "campaign-supervisor"
   )
 
-  startListener[DeviceInstallationReport](new DeviceInstallationReportListener())
+  startListener[DeviceInstallationReport](new DeviceInstallationReportListener(deviceRegistry))
   startListener[DeviceEventMessage](new DeviceEventListener(director))
 
   val routes: Route = (versionHeaders(version) & logResponseMetrics(projectName)) {

--- a/src/main/scala/com/advancedtelematic/campaigner/daemon/DeviceInstallationReportListener.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/daemon/DeviceInstallationReportListener.scala
@@ -1,17 +1,20 @@
 package com.advancedtelematic.campaigner.daemon
 
+import akka.http.scaladsl.util.FastFuture
 import cats.syntax.show._
+import com.advancedtelematic.campaigner.client.DeviceRegistryClient
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.db.{Campaigns, UpdateSupport}
 import com.advancedtelematic.campaigner.http.Errors
-import com.advancedtelematic.libats.data.DataType.{CampaignId => CampaignCorrelationId, MultiTargetUpdateId}
+import com.advancedtelematic.libats.data.DataType.{MultiTargetUpdateId, Namespace, CampaignId => CampaignCorrelationId}
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceInstallationReport
 import org.slf4j.LoggerFactory
 import slick.jdbc.MySQLProfile.api._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DeviceInstallationReportListener()(implicit db: Database, ec: ExecutionContext)
+class DeviceInstallationReportListener(deviceRegistryClient: DeviceRegistryClient)(implicit db: Database, ec: ExecutionContext)
   extends (DeviceInstallationReport => Future[Unit]) with UpdateSupport {
 
   private lazy val _log = LoggerFactory.getLogger(this.getClass)
@@ -19,14 +22,19 @@ class DeviceInstallationReportListener()(implicit db: Database, ec: ExecutionCon
   val campaigns = Campaigns()
 
   def apply(msg: DeviceInstallationReport): Future[Unit] = {
-    val resultStatus = if (msg.result.success)
-      DeviceStatus.successful
-    else
-      DeviceStatus.failed
+    val success = msg.result.success
+    val resultStatus = if (success) DeviceStatus.successful else DeviceStatus.failed
 
     val f = msg.correlationId match {
       case CampaignCorrelationId(uuid) =>
-        campaigns.finishDevices(CampaignId(uuid), Seq(msg.device), resultStatus)
+        val campaignId = CampaignId(uuid)
+        val addDeviceToFailedDeviceGroupFuture =
+          addDeviceToFailedDeviceGroup(msg.namespace, campaignId, msg.result.code, msg.device)
+        for {
+          _ <- campaigns.finishDevices(CampaignId(uuid), Seq(msg.device), resultStatus)
+          isMainCampaign <- campaigns.findClientCampaign(campaignId).map(_.parentCampaignId.isEmpty)
+          _ <- if (isMainCampaign && !success) addDeviceToFailedDeviceGroupFuture else Future.unit
+        } yield ()
       case MultiTargetUpdateId(uuid) => for {
         update <- updateRepo.findByExternalId(msg.namespace, ExternalUpdateId(uuid.toString))
         _ <- campaigns.finishDevice(update.uuid, msg.device, resultStatus)
@@ -40,4 +48,19 @@ class DeviceInstallationReportListener()(implicit db: Database, ec: ExecutionCon
         _log.info(s"Got DeviceUpdateReport for device ${msg.device.show} which is not scheduled by campaigner, ignoring this message.")
     }
   }
+
+  private def addDeviceToFailedDeviceGroup(ns: Namespace, campaignId: CampaignId, failureCode: String, deviceId: DeviceId): Future[Unit] =
+    findOrCreateFailedDeviceGroup(ns, campaignId, failureCode)
+      .flatMap(gid => deviceRegistryClient.addDeviceToGroup(ns, gid, deviceId))
+
+  private def findOrCreateFailedDeviceGroup(ns: Namespace, campaignId: CampaignId, failureCode: String): Future[GroupId] =
+    campaigns.fetchFailedGroupId(campaignId, failureCode).flatMap {
+      case Some(g) =>
+        FastFuture.successful(g)
+      case None =>
+        deviceRegistryClient
+          .createGroup(ns, s"failed-group-campaignId-$campaignId-failureCode-$failureCode")
+          .flatMap(gid => campaigns.persistFailedGroup(campaignId, gid, failureCode))
+    }
+
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
@@ -33,6 +33,9 @@ object Codecs {
   implicit val decoderCreateCampaign: Decoder[CreateCampaign] = deriveDecoder
   implicit val encoderCreateCampaign: Encoder[CreateCampaign] = deriveEncoder
 
+  implicit val decoderRetryFailedDevices: Decoder[RetryFailedDevices] = deriveDecoder
+  implicit val encoderRetryFailedDevices: Encoder[RetryFailedDevices] = deriveEncoder
+
   implicit val decoderCreateUpdate: Decoder[CreateUpdate] = deriveDecoder
   implicit val encoderCreateUpdate: Encoder[CreateUpdate] = deriveEncoder
 

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -151,6 +151,8 @@ object DataType {
     status: CancelTaskStatus
   )
 
+  final case class FailedGroup(campaignId: CampaignId, groupId: GroupId, failureCode: String)
+
   object SortBy {
     sealed trait SortBy
     case object Name      extends SortBy

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -84,6 +84,7 @@ object DataType {
       metadata.toList.flatten.map(_.toCampaignMetadata(campaignId))
   }
 
+  final case class RetryFailedDevices(failureCode: String)
 
   final case class GetCampaign(
     namespace: Namespace,

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -130,4 +130,16 @@ object Schema {
   }
   protected [db] val updates = TableQuery[UpdatesTable]
 
+  class FailedGroupsTable(tag: Tag) extends Table[FailedGroup](tag, "failed_groups") {
+    def campaignId = column[CampaignId]("campaign_id")
+    def groupId = column[GroupId]("group_id")
+    def failureCode = column[String]("failure_code")
+
+    def * = (campaignId, groupId, failureCode) <> ((FailedGroup.apply _).tupled, FailedGroup.unapply)
+
+    def pk = primaryKey("pk_failed_groups", (campaignId, failureCode))
+  }
+
+  protected[db] val failedGroups = TableQuery[FailedGroupsTable]
+
 }

--- a/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
@@ -44,8 +44,7 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope], director: 
           s"retryCampaignWith-mainCampaign-${mainCampaign.id.uuid}-failureCode-${request.failureCode}",
           mainCampaign.updateId,
           retryGroup,
-          Some(mainCampaign.id)
-        ).mkCampaign(ns)
+        ).mkRetryCampaign(ns, mainCampaign.id)
         campaigns.create(retryCampaign, retryGroup, Nil)
     }
   }

--- a/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{Directive1, Route}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.util.FastFuture
+import cats.data.NonEmptyList
 import com.advancedtelematic.campaigner.Settings
 import com.advancedtelematic.campaigner.client.DirectorClient
 import com.advancedtelematic.campaigner.data.AkkaSupport._
@@ -14,7 +15,7 @@ import com.advancedtelematic.campaigner.data.DataType.SortBy.SortBy
 import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.db.Campaigns
 import com.advancedtelematic.libats.auth.AuthedNamespaceScope
-import com.advancedtelematic.libats.data.DataType.{CorrelationId, CampaignId => CampaignCorrelationId, MultiTargetUpdateId, Namespace}
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, MultiTargetUpdateId, Namespace, CampaignId => CampaignCorrelationId}
 import com.advancedtelematic.libats.http.UUIDKeyAkka._
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
@@ -31,6 +32,22 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope], director: 
     val campaign = request.mkCampaign(ns)
     val metadata = request.mkCampaignMetadata(campaign.id)
     campaigns.create(campaign, request.groups, metadata)
+  }
+
+  def retryFailedDevices(ns: Namespace, mainCampaign: Campaign, request: RetryFailedDevices): Future[CampaignId] = {
+    campaigns.fetchFailedGroupId(mainCampaign.id, request.failureCode).flatMap {
+      case None =>
+        Future.failed(Errors.MissingFailedGroup)
+      case Some(gid) =>
+        val retryGroup = NonEmptyList.one(gid)
+        val retryCampaign = CreateCampaign(
+          s"retryCampaignWith-mainCampaign-${mainCampaign.id.uuid}-failureCode-${request.failureCode}",
+          mainCampaign.updateId,
+          retryGroup,
+          Some(mainCampaign.id)
+        ).mkCampaign(ns)
+        campaigns.create(retryCampaign, retryGroup, Nil)
+    }
   }
 
   def cancelDeviceUpdate(ns: Namespace, correlationId: CorrelationId, device: DeviceId)
@@ -79,14 +96,19 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope], director: 
               complete(campaigns.update(campaign.id, updated.name, updated.metadata.toList.flatten.map(_.toCampaignMetadata(campaign.id))))
             }
           } ~
-          (post & path("launch")) {
-            complete(campaigns.launch(campaign.id))
+          post {
+            path("launch") {
+              complete(campaigns.launch(campaign.id))
+            } ~
+            path("cancel") {
+              complete(campaigns.cancel(campaign.id))
+            } ~
+            (path("retry-failed") & entity(as[RetryFailedDevices])) { request =>
+              complete(StatusCodes.Created -> retryFailedDevices(ns, campaign, request))
+            }
           } ~
           (get & path("stats")) {
             complete(campaigns.campaignStats(campaign.id))
-          } ~
-          (post & path("cancel")) {
-            complete(campaigns.cancel(campaign.id))
           }
         }
       } ~

--- a/src/main/scala/com/advancedtelematic/campaigner/http/DeviceCampaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/DeviceCampaigns.scala
@@ -1,6 +1,5 @@
 package com.advancedtelematic.campaigner.http
 
-import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
 import cats.data.NonEmptyList
 import com.advancedtelematic.campaigner.client.{ExternalUpdate, ResolverClient, UserProfileClient}

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -11,6 +11,7 @@ object ErrorCodes {
   val MissingUpdateSource = ErrorCode("missing_update_source")
   val MissingParentCampaign = ErrorCode("missing_parent_campaign")
   val MissingUpdate = ErrorCode("missing_update")
+  val MissingFailedGroup = ErrorCode("missing_failed_group")
   val ConflictingMetadata = ErrorCode("campaign_metadata_already_exists")
   val CampaignAlreadyLaunched = ErrorCode("campaign_already_launched")
   val InvalidCounts = ErrorCode("invalid_stats_count")
@@ -37,6 +38,12 @@ object Errors {
     ErrorCodes.MissingParentCampaign,
     StatusCodes.PreconditionFailed,
     "The parent campaign for this retry campaign is invalid or does not exist."
+  )
+
+  val MissingFailedGroup = RawError(
+    ErrorCodes.MissingFailedGroup,
+    StatusCodes.PreconditionFailed,
+    "There is no failed device group for the given campaign and failure code."
   )
 
   val ConflictingCampaign = RawError(ErrorCodes.ConflictingCampaign, StatusCodes.Conflict, "campaign already exists")

--- a/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
@@ -83,6 +83,10 @@ class CampaignSupervisorSpec2 extends ActorSpec[CampaignSupervisor] with Campaig
                                   offset: Long,
                                   limit: Long): Future[Seq[DeviceId]] =
         FastFuture.successful(devs.drop(offset.toInt).take(limit.toInt))
+
+      override def createGroup(ns: Namespace, name: String): Future[GroupId] = ???
+
+      override def addDeviceToGroup(ns: Namespace, groupId: GroupId, deviceId: DeviceId): Future[Unit] = ???
     }
 
     campaigns.create(campaign, group, Seq.empty).futureValue

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -42,8 +42,7 @@ object Generators {
     update <- arbitrary[UpdateId]
     gs <- arbitrary[NonEmptyList[GroupId]]
     meta   <- Gen.option(genCampaignMetadata.map(List(_)))
-    parent = None
-  } yield CreateCampaign(n, update, gs, parent, meta)
+  } yield CreateCampaign(n, update, gs, meta)
 
   val genUpdateCampaign: Gen[UpdateCampaign] = for {
     n   <- arbitrary[String].suchThat(!_.isEmpty)

--- a/src/test/scala/com/advancedtelematic/campaigner/util/FakeClients.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/FakeClients.scala
@@ -74,6 +74,16 @@ class FakeDeviceRegistry extends DeviceRegistryClient {
   override def devicesInGroup(namespace: Namespace, groupId: GroupId, offset: Long, limit: Long): Future[Seq[DeviceId]] = Future.successful {
     allGroupDevices(groupId).slice(offset.toInt, (offset + limit).toInt)
   }
+
+  override def createGroup(ns: Namespace, name: String): Future[GroupId] = {
+    val groupId = GroupId.generate()
+    groups.put(groupId, Set())
+    Future.successful(groupId)
+  }
+
+  override def addDeviceToGroup(ns: Namespace, groupId: GroupId, deviceId: DeviceId): Future[Unit] = Future.successful {
+    groups.put(groupId, groups.get(groupId) + deviceId)
+  }
 }
 
 class SlowFakeDeviceRegistry extends FakeDeviceRegistry {

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -48,6 +48,9 @@ trait ResourceSpec extends ScalatestRouteTest
   def createCampaign(request: CreateCampaign): HttpRequest =
     Post(apiUri("campaigns"), request).withHeaders(header)
 
+  def createRetryCampaign(mainCampaignId: CampaignId, request: RetryFailedDevices): HttpRequest =
+    Post(apiUri(s"campaigns/${mainCampaignId.show}/retry-failed"), request).withHeaders(header)
+
   def createCampaignOk(request: CreateCampaign): CampaignId =
     createCampaign(request) ~> routes ~> check {
       status shouldBe Created


### PR DESCRIPTION
Built on #99.

If we (the BE) are gonna create and store the failure groups (see #99), then I don't see a good reason to expose them to the FE. It might be better to abstract this. After all the FE wants to retry devices that failed with a given failure group, they're not interested in how that's implemented.
So I've added this endpoint where the FE only needs to send the failure code. We have the failure group and the main campaign in the BE and we can create the retry campaign.
Any thoughts on this?