### PR TITLE
[OTA-2300] Store the result codes for each failed or successful device update.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= {
   val akkaV = "2.5.13"
   val akkaHttpV = "10.1.1"
   val libatsV = "0.2.1-2-g962e326"
-  val libtufV = "0.4.0-64-gcc807ad"
+  val libtufV = "0.6.0-5-g06e4bdd"
   val scalaTestV = "3.0.0"
   val slickV = "3.2.0"
 

--- a/src/main/resources/db/migration/V12__add_result_code_to_device_updates.sql
+++ b/src/main/resources/db/migration/V12__add_result_code_to_device_updates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device_updates ADD COLUMN result_code VARCHAR(255) NULL;

--- a/src/main/scala/com/advancedtelematic/campaigner/actor/CampaignCancel.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/actor/CampaignCancel.scala
@@ -47,7 +47,7 @@ class CampaignCanceler(director: DirectorClient,
 
   private def cancel(devs: Seq[DeviceId]): Future[Seq[DeviceId]] =
     director.cancelUpdate(ns, devs).flatMap{ affected =>
-      campaigns.finishDevices(campaign, affected, DeviceStatus.cancelled).map(_ => affected)
+      campaigns.cancelDevices(campaign, affected).map(_ => affected)
     }
 
   def run(): Future[Done] = for {

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -144,7 +144,8 @@ object DataType {
     campaign: CampaignId,
     update: UpdateId,
     device: DeviceId,
-    status: DeviceStatus
+    status: DeviceStatus,
+    resultCode: Option[String] = None
   )
 
   final case class CancelTask(

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -73,7 +73,25 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
   def markDevicesAccepted(campaign: CampaignId, update: UpdateId, devices: DeviceId*): Future[Unit] =
     deviceUpdateRepo.persistMany(devices.map { d => DeviceUpdate(campaign, update, d, DeviceStatus.accepted) })
 
-  def finishDevice(updateId: UpdateId, device: DeviceId, status: DeviceStatus, resultCode: Option[String] = None): Future[Unit] = db.run {
+  def succeedDevice(updateId: UpdateId, deviceId: DeviceId, successCode: String): Future[Unit] =
+    finishDevice(updateId, deviceId, DeviceStatus.successful, Some(successCode))
+
+  def succeedDevices(campaignId: CampaignId, devices: Seq[DeviceId], successCode: String): Future[Unit] =
+    finishDevices(campaignId, devices, DeviceStatus.successful, Some(successCode))
+
+  def failDevice(updateId: UpdateId, deviceId: DeviceId, failureCode: String): Future[Unit] =
+    finishDevice(updateId, deviceId, DeviceStatus.failed, Some(failureCode))
+
+  def failDevices(campaignId: CampaignId, devices: Seq[DeviceId], failureCode: String): Future[Unit] =
+    finishDevices(campaignId, devices, DeviceStatus.failed, Some(failureCode))
+
+  def cancelDevice(updateId: UpdateId, deviceId: DeviceId): Future[Unit] =
+    finishDevice(updateId, deviceId, DeviceStatus.cancelled, None)
+
+  def cancelDevices(campaignId: CampaignId, devices: Seq[DeviceId]): Future[Unit] =
+    finishDevices(campaignId, devices, DeviceStatus.cancelled, None)
+
+  private def finishDevice(updateId: UpdateId, device: DeviceId, status: DeviceStatus, resultCode: Option[String]): Future[Unit] = db.run {
     for {
       _ <- deviceUpdateRepo.setUpdateStatusAction(updateId, device, status, resultCode)
       campaigns <- campaignRepo.findByUpdateAction(updateId)
@@ -81,9 +99,9 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
     } yield ()
   }
 
-  def finishDevices(campaign: CampaignId, devices: Seq[DeviceId], status: DeviceStatus, resultCode: Option[String] = None): Future[Unit] = db.run {
-    deviceUpdateRepo.setUpdateStatusAction(campaign, devices, status, resultCode)
-      .andThen(campaignStatusTransition.devicesFinished(campaign))
+  private def finishDevices(campaignId: CampaignId, devices: Seq[DeviceId], status: DeviceStatus, resultCode: Option[String]): Future[Unit] = db.run {
+    deviceUpdateRepo.setUpdateStatusAction(campaignId, devices, status, resultCode)
+      .andThen(campaignStatusTransition.devicesFinished(campaignId))
   }
 
   def countByStatus: Future[Map[CampaignStatus, Int]] =

--- a/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
@@ -2,7 +2,7 @@ package com.advancedtelematic.campaigner.db
 
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.campaigner.client.DirectorClient
-import com.advancedtelematic.campaigner.data.DataType.{Campaign, CampaignId, DeviceStatus, UpdateType}
+import com.advancedtelematic.campaigner.data.DataType.{Campaign, CampaignId, UpdateType}
 import com.advancedtelematic.libats.data.DataType.{CampaignId => CampaignCorrelationId, Namespace}
 import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceId
 import org.slf4j.LoggerFactory
@@ -48,7 +48,7 @@ class DeviceUpdateProcess(director: DirectorClient)(implicit db: Database, ec: E
           _logger.warn(s"Could not start mtu update for device $deviceId after device accepted, device is no longer affected")
 
           campaigns.scheduleDevices(campaignId, campaign.update, deviceId).flatMap { _ =>
-            campaigns.finishDevice(campaign.update, deviceId, DeviceStatus.failed)
+            campaigns.failDevice(campaign.update, deviceId, "failure-code-1")
           }
       }
     } yield ()

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -86,10 +86,11 @@ object Schema {
     def updateId   = column[UpdateId]("update_id")
     def deviceId   = column[DeviceId]("device_id")
     def status     = column[DeviceStatus]("status")
+    def resultCode = column[Option[String]]("result_code")
 
     def pk = primaryKey("device_updates_pk", (campaignId, deviceId))
 
-    override def * = (campaignId, updateId, deviceId, status) <>
+    override def * = (campaignId, updateId, deviceId, status, resultCode) <>
                      ((DeviceUpdate.apply _).tupled, DeviceUpdate.unapply)
   }
 

--- a/src/main/scala/com/advancedtelematic/campaigner/http/DeviceCampaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/DeviceCampaigns.scala
@@ -1,6 +1,5 @@
 package com.advancedtelematic.campaigner.http
 
-import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
 import cats.data.NonEmptyList
 import com.advancedtelematic.campaigner.client.{ExternalUpdate, ResolverClient, UserProfileClient}

--- a/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
@@ -8,7 +8,7 @@ import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
 import com.advancedtelematic.campaigner.db.{Campaigns, DeviceUpdateSupport, UpdateSupport}
 import com.advancedtelematic.campaigner.util.{CampaignerSpec, DatabaseUpdateSpecUtil}
-import com.advancedtelematic.libats.data.DataType.{CampaignId => CampaignCorrelationId, MultiTargetUpdateId, CorrelationId}
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, MultiTargetUpdateId, CampaignId => CampaignCorrelationId}
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, InstallationResult}
 import com.advancedtelematic.libats.messaging_datatype.Messages.{
   DeviceUpdateEvent,
@@ -42,7 +42,7 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
   }
 
   "Listener" should "mark a device as successful using campaign CorrelationId" in {
-    val (updateSource, campaign, deviceUpdate) = prepareTest()
+    val (_, campaign, deviceUpdate) = prepareTest()
     val report = makeReport(
       campaign,
       deviceUpdate,
@@ -63,10 +63,11 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
     listener.apply(report).futureValue shouldBe (())
     deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.failed).futureValue should contain(deviceUpdate.device)
+    deviceUpdateRepo.findFailedByFailureCode(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
   }
 
   "Listener" should "mark a device as failed using campaign CorrelationId" in {
-    val (updateSource, campaign, deviceUpdate) = prepareTest()
+    val (_, campaign, deviceUpdate) = prepareTest()
     val report = makeReport(
       campaign,
       deviceUpdate,
@@ -75,10 +76,11 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
     listener.apply(report).futureValue shouldBe (())
     deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.failed).futureValue should contain(deviceUpdate.device)
+    deviceUpdateRepo.findFailedByFailureCode(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
   }
 
   "Listener" should "mark a device as canceled using campaign CorrelationId" in {
-    val (updateSource, campaign, deviceUpdate) = prepareTest()
+    val (_, campaign, deviceUpdate) = prepareTest()
     val event = DeviceUpdateCanceled(
       campaign.namespace,
       Instant.now,

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -50,7 +50,7 @@ object Generators {
     meta   <- genCampaignMetadata
   } yield UpdateCampaign(n, Option(List(meta)))
 
-  def genUpdateSource(genType: Gen[UpdateType]): Gen[UpdateSource] = for {
+  def genUpdateSource(genType: => Gen[UpdateType]): Gen[UpdateSource] = for {
     id <- arbitrary[String].suchThat(_.length < 200)
     t <- genType
   } yield UpdateSource(ExternalUpdateId(id), t)

--- a/src/test/scala/com/advancedtelematic/campaigner/db/CampaignsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/db/CampaignsSpec.scala
@@ -112,7 +112,7 @@ class CampaignsSpec extends AsyncFlatSpec
       update <- createDbUpdate(UpdateId.generate())
       newCampaigns <- FastFuture.traverse(arbitrary[Seq[Int]].generate)(_ => createDbCampaign(ns, update, group))
       _ <- FastFuture.traverse(newCampaigns)(c => campaigns.scheduleDevices(c.id, update, device))
-      _ <- campaigns.finishDevice(update, device, DeviceStatus.successful)
+      _ <- campaigns.succeedDevice(update, device, "success-code-1")
       stats <- campaigns.campaignStats(newCampaigns.head.id)
     } yield stats.finished shouldBe 1
   }
@@ -123,7 +123,7 @@ class CampaignsSpec extends AsyncFlatSpec
     for {
       campaign <- createDbCampaignWithUpdate()
       _ <- FastFuture.traverse(devices)(d => campaigns.scheduleDevices(campaign.id, campaign.updateId, d))
-      _ <- FastFuture.traverse(devices)(d => campaigns.finishDevice(campaign.updateId, d, DeviceStatus.failed))
+      _ <- FastFuture.traverse(devices)(d => campaigns.failDevice(campaign.updateId, d, "failure-code-1"))
       stats <- campaigns.campaignStats(campaign.id)
     } yield stats.finished shouldBe devices.length
   }

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -13,7 +13,7 @@ import com.advancedtelematic.campaigner.db.{CampaignSupport, Campaigns}
 import com.advancedtelematic.campaigner.util.{CampaignerSpec, ResourceSpec, UpdateResourceSpecUtil}
 import com.advancedtelematic.libats.data.ErrorCodes.InvalidEntity
 import com.advancedtelematic.libats.data.ErrorRepresentation
-import com.advancedtelematic.libats.data.DataType.{CorrelationId, CampaignId => CampaignCorrelationId, MultiTargetUpdateId}
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, MultiTargetUpdateId}
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -342,12 +342,12 @@ class CampaignResourceSpec
       _ <- campaigns.launch(campaignId)
       _ <- campaigns.completeGroup(campaignId, campaignCase.groupId, campaignCase.groupStats)
       _ <- campaigns.scheduleDevices(campaignId, campaign.update, campaignCase.affectedDevices:_*)
-      _ <- campaigns.finishDevices(campaignId, campaignCase.cancelledDevices, DeviceStatus.cancelled)
-      _ <- campaigns.finishDevices(campaignId, campaignCase.failedDevices, DeviceStatus.failed)
-      _ <- campaigns.finishDevices(campaignId, campaignCase.successfulDevices, DeviceStatus.successful)
+      _ <- campaigns.cancelDevices(campaignId, campaignCase.cancelledDevices)
+      _ <- campaigns.failDevices(campaignId, campaignCase.failedDevices, "failure-code-1")
+      _ <- campaigns.succeedDevices(campaignId, campaignCase.successfulDevices, "success-code-1")
     } yield ()
 
-    forAll (genCampaignCase) ((mainCase) => {
+    forAll (genCampaignCase) (mainCase => {
       val (mainCampaignId, mainCampaign) = createCampaignWithUpdateOk(
         genCreateCampaign().map(_.copy(groups = NonEmptyList.one(mainCase.groupId)))
       )


### PR DESCRIPTION
When parsing the installation reports, we now store the failure codes for the failed devices. We can later query to get the failed devices by failure code and use them to create a new retry-campaign.

https://saeljira.it.here.com/browse/OTA-2300