### PR TITLE
Use new campaign vocabulary: rename `parent` to `main` and `child` to `retry`

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -30,7 +30,7 @@ object DataType {
     status: CampaignStatus,
     createdAt: Instant,
     updatedAt: Instant,
-    parentCampaignId: Option[CampaignId],
+    mainCampaignId: Option[CampaignId],
     autoAccept: Boolean = true
   )
 
@@ -62,7 +62,7 @@ object DataType {
   final case class CreateCampaign(name: String,
                                   update: UpdateId,
                                   groups: NonEmptyList[GroupId],
-                                  parentCampaignId: Option[CampaignId],
+                                  mainCampaignId: Option[CampaignId],
                                   metadata: Option[Seq[CreateCampaignMetadata]] = None,
                                   approvalNeeded: Option[Boolean] = Some(false))
   {
@@ -75,7 +75,7 @@ object DataType {
         CampaignStatus.prepared,
         Instant.now(),
         Instant.now(),
-        parentCampaignId,
+        mainCampaignId,
         !approvalNeeded.getOrElse(false)
       )
     }
@@ -93,15 +93,15 @@ object DataType {
     status: CampaignStatus,
     createdAt: Instant,
     updatedAt: Instant,
-    parentCampaignId: Option[CampaignId],
-    childCampaignIds: Set[CampaignId],
+    mainCampaignId: Option[CampaignId],
+    retryCampaignIds: Set[CampaignId],
     groups: Set[GroupId],
     metadata: Seq[CreateCampaignMetadata],
     autoAccept: Boolean
   )
 
   object GetCampaign {
-    def apply(c: Campaign, childCampaignIds: Set[CampaignId], groups: Set[GroupId], metadata: Seq[CampaignMetadata]): GetCampaign =
+    def apply(c: Campaign, retryCampaignIds: Set[CampaignId], groups: Set[GroupId], metadata: Seq[CampaignMetadata]): GetCampaign =
       GetCampaign(
         c.namespace,
         c.id,
@@ -110,8 +110,8 @@ object DataType {
         c.status,
         c.createdAt,
         c.updatedAt,
-        c.parentCampaignId,
-        childCampaignIds,
+        c.mainCampaignId,
+        retryCampaignIds,
         groups,
         metadata.map(m => CreateCampaignMetadata(m.`type`, m.value)),
         c.autoAccept

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -137,10 +137,10 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
 
   def findClientCampaign(campaignId: CampaignId): Future[GetCampaign] = for {
     c <- campaignRepo.find(campaignId)
-    childIds <- campaignRepo.findChildIdsOf(campaignId)
+    retryIds <- campaignRepo.findRetryCampaignIdsOf(campaignId)
     groups <- db.run(findGroupsAction(c.id))
     metadata <- campaignMetadataRepo.findFor(campaignId)
-  } yield GetCampaign(c, childIds, groups, metadata)
+  } yield GetCampaign(c, retryIds, groups, metadata)
 
   def findCampaignsByUpdate(update: UpdateId): Future[Seq[Campaign]] =
     db.run(campaignRepo.findByUpdateAction(update))
@@ -152,7 +152,7 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
   def campaignStats(campaignId: CampaignId): Future[CampaignStats] = db.run {
     val statsAction = for {
       mainCampaign <- campaignRepo.findAction(campaignId)
-      retryCampaignIds <- campaignRepo.findChildIdsOfAction(campaignId)
+      retryCampaignIds <- campaignRepo.findRetryCampaignIdsOfAction(campaignId)
       (mainProcessed, mainAffected) <- countProcessedAndAffectedDevicesForAllOfAction(Set(campaignId))
       (retryProcessed, retryAffected) <- countProcessedAndAffectedDevicesForAllOfAction(retryCampaignIds)
       mainCancelled <- countCancelledAction(Set(campaignId))

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -29,11 +29,11 @@ object Schema {
     def autoAccept = column[Boolean]   ("auto_accept")
     def createdAt = column[Instant]   ("created_at")
     def updatedAt = column[Instant]   ("updated_at")
-    def parentCampaignId = column[Option[CampaignId]]("parent_campaign_uuid")
+    def mainCampaignId = column[Option[CampaignId]]("parent_campaign_uuid")
 
     def updateForeignKey = foreignKey("update_fk", update, updates)(_.uuid)
 
-    override def * = (namespace, id, name, update, status, createdAt, updatedAt, parentCampaignId, autoAccept) <>
+    override def * = (namespace, id, name, update, status, createdAt, updatedAt, mainCampaignId, autoAccept) <>
       ((Campaign.apply _).tupled, Campaign.unapply)
   }
 

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -9,7 +9,7 @@ import com.advancedtelematic.libats.messaging_datatype.DataType.UpdateId
 object ErrorCodes {
   val ConflictingCampaign = ErrorCode("campaign_already_exists")
   val MissingUpdateSource = ErrorCode("missing_update_source")
-  val MissingParentCampaign = ErrorCode("missing_parent_campaign")
+  val MissingMainCampaign = ErrorCode("missing_main_campaign")
   val MissingUpdate = ErrorCode("missing_update")
   val ConflictingMetadata = ErrorCode("campaign_metadata_already_exists")
   val CampaignAlreadyLaunched = ErrorCode("campaign_already_launched")
@@ -33,10 +33,10 @@ object Errors {
     "The update associated with the given campaign does not exist."
   )
 
-  val MissingParentCampaign = RawError(
-    ErrorCodes.MissingParentCampaign,
+  val MissingMainCampaign = RawError(
+    ErrorCodes.MissingMainCampaign,
     StatusCodes.PreconditionFailed,
-    "The parent campaign for this retry campaign is invalid or does not exist."
+    "The main campaign for this retry campaign is invalid or does not exist."
   )
 
   val ConflictingCampaign = RawError(ErrorCodes.ConflictingCampaign, StatusCodes.Conflict, "campaign already exists")

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -34,16 +34,16 @@ object Generators {
     update <- arbitrary[UpdateId]
     ca      = Instant.now()
     ua      = Instant.now()
-    parent  = None
-  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, ca, ua, parent)
+    mainId  = None
+  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, ca, ua, mainId)
 
   def genCreateCampaign(genName: Gen[String] = arbitrary[String]): Gen[CreateCampaign] = for {
     n   <- genName
     update <- arbitrary[UpdateId]
     gs <- arbitrary[NonEmptyList[GroupId]]
     meta   <- Gen.option(genCampaignMetadata.map(List(_)))
-    parent = None
-  } yield CreateCampaign(n, update, gs, parent, meta)
+    mainId = None
+  } yield CreateCampaign(n, update, gs, mainId, meta)
 
   val genUpdateCampaign: Gen[UpdateCampaign] = for {
     n   <- arbitrary[String].suchThat(!_.isEmpty)


### PR DESCRIPTION
This refactor is separated from #100. The db field is not renamed yet because of #104, which will probably merged later than this PR.

Since the PR doesn't break anything or change any logic, I think it's okay to merge it without explicit approval from seniors, but @koshelev @simao @jerrytrieu you're free to take a look if you want to.