### PR TITLE
[OTA-2306] Create new endpoint to launch a retry-campaign

### DIFF
--- a/src/main/resources/db/migration/V15__add_failure_code_to_campaign.sql
+++ b/src/main/resources/db/migration/V15__add_failure_code_to_campaign.sql
@@ -1,0 +1,1 @@
+ALTER TABLE campaigns ADD COLUMN failure_code VARCHAR(255) NULL;

--- a/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
@@ -33,6 +33,9 @@ object Codecs {
   implicit val decoderCreateCampaign: Decoder[CreateCampaign] = deriveDecoder
   implicit val encoderCreateCampaign: Encoder[CreateCampaign] = deriveEncoder
 
+  implicit val decoderRetryFailedDevices: Decoder[RetryFailedDevices] = deriveDecoder
+  implicit val encoderRetryFailedDevices: Encoder[RetryFailedDevices] = deriveEncoder
+
   implicit val decoderCreateUpdate: Decoder[CreateUpdate] = deriveDecoder
   implicit val encoderCreateUpdate: Encoder[CreateUpdate] = deriveEncoder
 

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -30,7 +30,6 @@ object DataType {
     createdAt: Instant,
     updatedAt: Instant,
     mainCampaignId: Option[CampaignId],
-    // TODO ensure that they're both either Some or None
     failureCode: Option[String],
     autoAccept: Boolean = true
   )
@@ -63,8 +62,6 @@ object DataType {
   final case class CreateCampaign(name: String,
                                   update: UpdateId,
                                   groups: NonEmptyList[GroupId],
-                                 // TODO remove mainCampaignId from here, we should use the other endpoint to launch a retry campaign.
-                                  mainCampaignId: Option[CampaignId],
                                   metadata: Option[Seq[CreateCampaignMetadata]] = None,
                                   approvalNeeded: Option[Boolean] = Some(false))
   {
@@ -77,7 +74,7 @@ object DataType {
         CampaignStatus.prepared,
         Instant.now(),
         Instant.now(),
-        mainCampaignId,
+        None,
         None,
         !approvalNeeded.getOrElse(false)
       )
@@ -85,26 +82,6 @@ object DataType {
 
     def mkCampaignMetadata(campaignId: CampaignId): Seq[CampaignMetadata] =
       metadata.toList.flatten.map(_.toCampaignMetadata(campaignId))
-  }
-
-  final case class CreateRetryCampaign(name: String,
-                                       update: UpdateId,
-                                       group: GroupId,
-                                       mainCampaignId: CampaignId,
-                                       failureCode: String
-                                      ) {
-    def mkCampaign(ns: Namespace): Campaign =
-      Campaign(
-        ns,
-        CampaignId.generate(),
-        name,
-        update,
-        CampaignStatus.prepared,
-        Instant.now(),
-        Instant.now(),
-        Some(mainCampaignId),
-        Some(failureCode)
-      )
   }
 
   final case class RetryFailedDevices(failureCode: String)

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -83,6 +83,16 @@ object DataType {
       metadata.toList.flatten.map(_.toCampaignMetadata(campaignId))
   }
 
+  final case class CreateRetryCampaign(name: String,
+                                       update: UpdateId,
+                                       group: GroupId,
+                                       mainCampaignId: CampaignId,
+                                      ) {
+    def mkCampaign(ns: Namespace): Campaign =
+      CreateCampaign(name, update, NonEmptyList.one(group), Some(mainCampaignId)).mkCampaign(ns)
+  }
+
+  final case class RetryFailedDevices(failureCode: String)
 
   final case class GetCampaign(
     namespace: Namespace,

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -111,6 +111,13 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
       .andThen(campaignStatusTransition.devicesFinished(campaignId))
   }
 
+  /**
+    * Returns the IDs of all the devices that were processed in the campaign with `campaignId` and failed with
+    * the code `failureCode`.
+    */
+  def fetchFailedDevices(campaignId: CampaignId, failureCode: String): Future[Set[DeviceId]] =
+    deviceUpdateRepo.findFailedByFailureCode(campaignId, failureCode)
+
   def countByStatus: Future[Map[CampaignStatus, Int]] =
     db
       .run(campaignRepo.countByStatus)

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Campaigns.scala
@@ -1,5 +1,7 @@
 package com.advancedtelematic.campaigner.db
 
+import java.time.Instant
+
 import cats.syntax.either._
 import com.advancedtelematic.campaigner.data.DataType.CampaignStatus.CampaignStatus
 import com.advancedtelematic.campaigner.data.DataType.DeviceStatus.DeviceStatus
@@ -203,6 +205,31 @@ protected [db] class Campaigns(implicit db: Database, ec: ExecutionContext)
 
   def create(campaign: Campaign, groups: Set[GroupId], devices: Set[DeviceId], metadata: Seq[CampaignMetadata]): Future[CampaignId] =
     campaignRepo.persist(campaign, groups, devices, metadata)
+
+  /**
+    * Create and immediately launch a retry-campaign for all the devices that were processed by `mainCampaign` and
+    * failed with a code `failureCode`. There should be at least one failed device with that code. If there were not
+    * any such devices in `mainCampaign`, an exception is thrown.
+    */
+  def retryCampaign(ns: Namespace, mainCampaign: Campaign, failureCode: String): Future[CampaignId] =
+    fetchFailedDevices(mainCampaign.id, failureCode).flatMap {
+      case deviceIds if deviceIds.isEmpty =>
+        Future.failed(MissingFailedDevices(failureCode))
+      case deviceIds =>
+        val retryCampaign = Campaign(
+          ns,
+          CampaignId.generate(),
+          s"retryCampaignWith-mainCampaign-${mainCampaign.id.uuid}-failureCode-$failureCode",
+          mainCampaign.updateId,
+          CampaignStatus.prepared,
+          Instant.now(),
+          Instant.now(),
+          Some(mainCampaign.id),
+          Some(failureCode)
+        )
+        create(retryCampaign, Set.empty, deviceIds, Nil)
+    }
+    .map { cid => launch(cid); cid }
 
   def update(id: CampaignId, name: String, metadata: Seq[CampaignMetadata]): Future[Unit] =
     campaignRepo.update(id, name, metadata)

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
@@ -89,9 +89,10 @@ protected [db] class DeviceUpdateRepository()(implicit db: Database, ec: Executi
     }
 
   /**
-    * Find all the device updates that failed with a given failure code.
+    * Returns the IDs of all the devices that were processed in the campaign with `campaignId` and failed with
+    * the code `failureCode`.
     */
-  def findFailedByFailureCode(campaignId: CampaignId, failureCode: String): Future[Set[DeviceId]] = db.run {
+  protected [db] def findFailedByFailureCode(campaignId: CampaignId, failureCode: String): Future[Set[DeviceId]] = db.run {
     Schema.deviceUpdates
       .filter(_.campaignId === campaignId)
       .filter(_.status === DeviceStatus.failed)

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -25,14 +25,15 @@ object Schema {
     def name      = column[String]    ("name")
     def status = column[CampaignStatus]("status")
     def update    = column[UpdateId]  ("update_uuid")
+    def mainCampaignId = column[Option[CampaignId]]("parent_campaign_uuid")
+    def failureCode = column[Option[String]]("failure_code")
     def autoAccept = column[Boolean]   ("auto_accept")
     def createdAt = column[Instant]   ("created_at")
     def updatedAt = column[Instant]   ("updated_at")
-    def mainCampaignId = column[Option[CampaignId]]("parent_campaign_uuid")
 
     def updateForeignKey = foreignKey("update_fk", update, updates)(_.uuid)
 
-    override def * = (namespace, id, name, update, status, createdAt, updatedAt, mainCampaignId, autoAccept) <>
+    override def * = (namespace, id, name, update, status, createdAt, updatedAt, mainCampaignId, failureCode, autoAccept) <>
       ((Campaign.apply _).tupled, Campaign.unapply)
   }
 

--- a/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
@@ -58,6 +58,7 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope],
           mainCampaign.updateId,
           retryGroup,
           mainCampaign.id,
+          request.failureCode
         ).mkCampaign(ns)
 
         campaigns

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -10,6 +10,7 @@ object ErrorCodes {
   val ConflictingCampaign = ErrorCode("campaign_already_exists")
   val MissingUpdateSource = ErrorCode("missing_update_source")
   val MissingMainCampaign = ErrorCode("missing_main_campaign")
+  val MissingFailedDevices = ErrorCode("missing_failed_devices")
   val MissingUpdate = ErrorCode("missing_update")
   val ConflictingMetadata = ErrorCode("campaign_metadata_already_exists")
   val CampaignAlreadyLaunched = ErrorCode("campaign_already_launched")
@@ -26,6 +27,12 @@ object Errors {
   case class MissingUpdate(id: UpdateId) extends Error(ErrorCodes.MissingUpdate, StatusCodes.NotFound, s"Missing $id")
 
   case class MissingExternalUpdate(externalUpdateId: ExternalUpdateId) extends Error(ErrorCodes.MissingUpdate, StatusCodes.NotFound, s"Missing $externalUpdateId")
+
+  case class MissingFailedDevices(failureCode: String) extends Error(
+    ErrorCodes.MissingFailedDevices,
+    StatusCodes.PreconditionFailed,
+    s"You are attempting to retry failed devices, but no devices failed with the code '$failureCode'."
+  )
 
   val MissingUpdateSource = RawError(
     ErrorCodes.MissingUpdateSource,

--- a/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
@@ -62,7 +62,7 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
     listener.apply(report).futureValue shouldBe (())
     deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.failed).futureValue should contain(deviceUpdate.device)
-    deviceUpdateRepo.findFailedByFailureCode(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
+    campaigns.fetchFailedDevices(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
   }
 
   "Listener" should "mark a device as failed using campaign CorrelationId" in {
@@ -75,7 +75,7 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
     listener.apply(report).futureValue shouldBe (())
     deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.failed).futureValue should contain(deviceUpdate.device)
-    deviceUpdateRepo.findFailedByFailureCode(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
+    campaigns.fetchFailedDevices(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
   }
 
   "Listener" should "mark a device as canceled using campaign CorrelationId" in {

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -32,10 +32,8 @@ object Generators {
     id     <- arbitrary[CampaignId]
     n       = id.uuid.toString.take(5)
     update <- arbitrary[UpdateId]
-    ca      = Instant.now()
-    ua      = Instant.now()
-    mainId  = None
-  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, ca, ua, mainId)
+    now      = Instant.now()
+  } yield Campaign(ns, id, n, update, CampaignStatus.prepared, now, now, None, None)
 
   def genCreateCampaign(genName: Gen[String] = arbitrary[String]): Gen[CreateCampaign] = for {
     n   <- genName

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -40,8 +40,7 @@ object Generators {
     update <- arbitrary[UpdateId]
     gs <- arbitrary[NonEmptyList[GroupId]]
     meta   <- Gen.option(genCampaignMetadata.map(List(_)))
-    mainId = None
-  } yield CreateCampaign(n, update, gs, mainId, meta)
+  } yield CreateCampaign(n, update, gs, meta)
 
   val genUpdateCampaign: Gen[UpdateCampaign] = for {
     n   <- arbitrary[String].suchThat(!_.isEmpty)

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -1,5 +1,7 @@
 package com.advancedtelematic.campaigner.http
 
+import java.time.temporal.ChronoUnit
+
 import akka.http.scaladsl.model.StatusCodes._
 import cats.data.NonEmptyList
 import cats.syntax.either._
@@ -11,9 +13,9 @@ import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
 import com.advancedtelematic.campaigner.db.{CampaignSupport, Campaigns, DeviceUpdateSupport}
 import com.advancedtelematic.campaigner.util.{CampaignerSpec, ResourceSpec, UpdateResourceSpecUtil}
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, MultiTargetUpdateId}
 import com.advancedtelematic.libats.data.ErrorCodes.InvalidEntity
 import com.advancedtelematic.libats.data.ErrorRepresentation
-import com.advancedtelematic.libats.data.DataType.{CorrelationId, MultiTargetUpdateId}
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, UpdateId}
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json
@@ -60,7 +62,7 @@ class CampaignResourceSpec
       CampaignStatus.prepared,
       campaign.createdAt,
       campaign.updatedAt,
-      request.mainCampaignId,
+      None,
       Set.empty,
       request.groups.toList.toSet,
       request.metadata.toList.flatten,
@@ -72,66 +74,6 @@ class CampaignResourceSpec
     campaigns.values should contain (id)
 
     checkStats(id, CampaignStatus.prepared)
-  }
-
-  "POST /campaigns" should "set mainCampaignId if a valid one is given" in {
-    Given("a valid main campaign ID")
-    val (mainId, _) = createCampaignWithUpdateOk()
-
-    When("a retry campaign is created")
-    val (retryId, request) = createCampaignWithUpdateOk(
-      genCreateCampaign().map(_.copy(mainCampaignId = Some(mainId))))
-
-    Then("the retry campaign should have the main campaign ID and other properties")
-    val retryCampaign = getCampaignOk(retryId)
-    retryCampaign shouldBe GetCampaign(
-      testNs,
-      retryId,
-      request.name,
-      request.update,
-      CampaignStatus.prepared,
-      retryCampaign.createdAt,
-      retryCampaign.updatedAt,
-      Some(mainId),
-      Set.empty,
-      request.groups.toList.toSet,
-      request.metadata.toList.flatten,
-      autoAccept = true
-    )
-    retryCampaign.createdAt shouldBe retryCampaign.updatedAt
-
-    And("the list of all campaigns should NOT list the retry campaign")
-    val campaigns = getCampaignsOk()
-    campaigns.values should not contain retryId
-
-    And("the retry campaign should have `prepared` status")
-    checkStats(retryId, CampaignStatus.prepared)
-
-    And("the main campaign should have the retry campaign in retry campaigns list")
-    val mainCampaign = getCampaignOk(mainId)
-    mainCampaign.retryCampaignIds should contain(retryId)
-  }
-
-  "POST /campaigns" should "fail if mainCampaignId does not refer to an existing campaign" in {
-      Given("a valid update")
-      val createUpdate = genCreateUpdate().map(cu =>
-          cu.copy(updateSource = UpdateSource(cu.updateSource.id, UpdateType.multi_target))
-      ).sample.get
-      val updateId = createUpdateOk(createUpdate)
-
-      Given("a non-existing main campaign ID")
-      val genCreateCampaignWithInvalidMainId = for {
-        createCampaign <- genCreateCampaign()
-        mainId <- arbitrary[CampaignId]
-      } yield createCampaign.copy(mainCampaignId = Some(mainId), update = updateId)
-      val createCampaignWithInvalidMainId = genCreateCampaignWithInvalidMainId.sample.get
-
-      When("a retry campaign is created")
-      Then("a PreconditionFailed error is raised")
-      createCampaign(createCampaignWithInvalidMainId) ~> routes ~> check {
-        status shouldBe PreconditionFailed
-        responseAs[ErrorRepresentation].code shouldBe Errors.MissingMainCampaign.code
-      }
   }
 
   "POST/GET autoAccept campaign" should "create and return the created campaign" in {
@@ -147,7 +89,7 @@ class CampaignResourceSpec
       CampaignStatus.prepared,
       campaign.createdAt,
       campaign.updatedAt,
-      request.mainCampaignId,
+      None,
       Set.empty,
       request.groups.toList.toSet,
       request.metadata.toList.flatten,
@@ -186,25 +128,43 @@ class CampaignResourceSpec
     checkStats(id, CampaignStatus.prepared)
   }
 
-  "POST /campaigns/:campaign_id/retry-failed" should "create a retry-campaign" in {
-    val (campaignId, campaign) = createCampaignWithUpdateOk()
+  "POST /campaigns/:campaign_id/retry-failed" should "create and launch a retry-campaign" in {
+    val (mainCampaignId, mainCampaign) = createCampaignWithUpdateOk()
     val deviceId = genDeviceId.generate
     val failureCode = "failureCode-1"
-    val deviceUpdate = DeviceUpdate(campaignId, campaign.update, deviceId, DeviceStatus.accepted, Some(failureCode))
+    val deviceUpdate = DeviceUpdate(mainCampaignId, mainCampaign.update, deviceId, DeviceStatus.accepted, Some(failureCode))
 
     deviceUpdateRepo.persistMany(deviceUpdate :: Nil).futureValue
-    campaigns.failDevices(campaignId, deviceId :: Nil, failureCode).futureValue
+    campaigns.failDevices(mainCampaignId, deviceId :: Nil, failureCode).futureValue
 
-    createRetryCampaign(campaignId, RetryFailedDevices(failureCode)) ~> routes ~> check {
+    val retryCampaignId = createAndLaunchRetryCampaign(mainCampaignId, RetryFailedDevices(failureCode)) ~> routes ~> check {
       status shouldBe Created
+      responseAs[CampaignId]
     }
+
+    val retryCampaign = getCampaignOk(retryCampaignId)
+    retryCampaign shouldBe GetCampaign(
+      testNs,
+      retryCampaignId,
+      s"retryCampaignWith-mainCampaign-${mainCampaignId.uuid}-failureCode-$failureCode",
+      mainCampaign.update,
+      CampaignStatus.launched,
+      retryCampaign.createdAt,
+      retryCampaign.updatedAt,
+      Some(mainCampaignId),
+      Set.empty,
+      Set.empty,
+      Nil,
+      autoAccept = true
+    )
+    retryCampaign.createdAt.truncatedTo(ChronoUnit.SECONDS) shouldBe retryCampaign.updatedAt.truncatedTo(ChronoUnit.SECONDS)
   }
 
   "POST /campaigns/:campaign_id/retry-failed" should "fail if there are no failed devices for the given failure code" in {
     val (campaignId, _) = createCampaignWithUpdateOk()
     val request = RetryFailedDevices("failureCode-2")
 
-    createRetryCampaign(campaignId, request) ~> routes ~> check {
+    createAndLaunchRetryCampaign(campaignId, request) ~> routes ~> check {
       status shouldBe PreconditionFailed
       responseAs[ErrorRepresentation].code shouldBe Errors.MissingFailedDevices(request.failureCode).code
     }
@@ -212,7 +172,7 @@ class CampaignResourceSpec
 
   "POST /campaigns/:campaign_id/retry-failed" should "fail if there is no main campaign with id :campaign_id" in {
     val request = RetryFailedDevices("failureCode-3")
-    createRetryCampaign(CampaignId.generate(), request) ~> routes ~> check {
+    createAndLaunchRetryCampaign(CampaignId.generate(), request) ~> routes ~> check {
       status shouldBe NotFound
       responseAs[ErrorRepresentation].code shouldBe Errors.CampaignMissing.code
     }
@@ -349,6 +309,7 @@ class CampaignResourceSpec
 
   "GET /campaigns/:id/stats" should "return correct statistics" in {
     val campaigns = Campaigns()
+    val failureCode = "failure-code-1"
 
     case class CampaignCase(
         successfulDevices: Seq[DeviceId],
@@ -372,20 +333,22 @@ class CampaignResourceSpec
       notAffectedDevices <- Gen.listOf(genDeviceId)
     } yield CampaignCase(successfulDevices, failedDevices, cancelledDevices, notAffectedDevices)
 
-    def conductCampaign(campaignId: CampaignId, campaign: CreateCampaign, campaignCase: CampaignCase): Future[Unit] = for {
-      _ <- campaigns.launch(campaignId)
-      _ <- campaigns.scheduleDevices(campaignId, campaign.update, campaignCase.affectedDevices:_*)
-      _ <- campaigns.rejectDevices(campaignId, campaign.update, campaignCase.notAffectedDevices)
+    def conductCampaign(campaignId: CampaignId, updateId: UpdateId, campaignCase: CampaignCase): Future[Unit] = for {
+      _ <- campaigns.scheduleDevices(campaignId, updateId, campaignCase.affectedDevices:_*)
+      _ <- campaigns.rejectDevices(campaignId, updateId, campaignCase.notAffectedDevices)
       _ <- campaigns.cancelDevices(campaignId, campaignCase.cancelledDevices)
-      _ <- campaigns.failDevices(campaignId, campaignCase.failedDevices, "failure-code-1")
+      _ <- campaigns.failDevices(campaignId, campaignCase.failedDevices, failureCode)
       _ <- campaigns.succeedDevices(campaignId, campaignCase.successfulDevices, "success-code-1")
     } yield ()
 
-    forAll (genCampaignCase) (mainCase => {
+    forAll(genCampaignCase) { mainCase =>
       val (mainCampaignId, mainCampaign) = createCampaignWithUpdateOk(
         genCreateCampaign().map(_.copy(groups = NonEmptyList.one(mainCase.groupId)))
       )
-      conductCampaign(mainCampaignId, mainCampaign, mainCase).futureValue
+      campaigns
+        .launch(mainCampaignId)
+        .flatMap(_ => conductCampaign(mainCampaignId, mainCampaign.update, mainCase))
+        .futureValue
 
       Get(apiUri(s"campaigns/${mainCampaignId.show}/stats")).withHeaders(header) ~> routes ~> check {
         status shouldBe OK
@@ -408,12 +371,11 @@ class CampaignResourceSpec
         notAffectedDevices = notAffectedDevices
       )
 
-      val (retryCampaignId, retryCampaign) = createCampaignWithUpdateOk(
-        genCreateCampaign().map(_.copy(
-          groups = NonEmptyList.one(retryCase.groupId),
-          mainCampaignId = Some(mainCampaignId)
-        )))
-      conductCampaign(retryCampaignId, retryCampaign, retryCase).futureValue
+      // We'll get a 412 Precondition Error if we try to launch a retry-campaign with no failed devices. See test above.
+      if (mainCase.failedDevices.nonEmpty) {
+        val retryCampaignId = createAndLaunchRetryCampaignOk(mainCampaignId, RetryFailedDevices(failureCode))
+        conductCampaign(retryCampaignId, mainCampaign.update, retryCase).futureValue
+      }
 
       Get(apiUri(s"campaigns/${mainCampaignId.show}/stats")).withHeaders(header) ~> routes ~> check {
         status shouldBe OK
@@ -422,16 +384,15 @@ class CampaignResourceSpec
         campaignStats.status shouldBe CampaignStatus.finished
         campaignStats.finished shouldBe (
           mainCase.successfulDevices.size + mainCase.failedDevices.size -
-          (retryCase.processedCount - retryCase.affectedCount + retryCase.cancelledDevices.size)
-        )
+            (retryCase.processedCount - retryCase.affectedCount + retryCase.cancelledDevices.size)
+          )
         campaignStats.cancelled shouldBe (mainCase.cancelledDevices.size + retryCase.cancelledDevices.size)
         campaignStats.processed shouldBe mainCase.processedCount
         campaignStats.affected shouldBe (
-          mainCase.affectedCount -
-          (retryCase.processedCount - retryCase.affectedCount)
-        )
+          mainCase.affectedCount - (retryCase.processedCount - retryCase.affectedCount)
+          )
       }
-    })
+    }
   }
 
   private def splitIntoGroupsRandomly[T](seq: Seq[T], n: Int): Seq[Seq[T]] = {

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -48,6 +48,9 @@ trait ResourceSpec extends ScalatestRouteTest
   def createCampaign(request: CreateCampaign): HttpRequest =
     Post(apiUri("campaigns"), request).withHeaders(header)
 
+  def createRetryCampaign(mainCampaignId: CampaignId, request: RetryFailedDevices): HttpRequest =
+    Post(apiUri(s"campaigns/${mainCampaignId.show}/retry-failed"), request).withHeaders(header)
+
   def createCampaignOk(request: CreateCampaign): CampaignId =
     createCampaign(request) ~> routes ~> check {
       status shouldBe Created

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -48,11 +48,17 @@ trait ResourceSpec extends ScalatestRouteTest
   def createCampaign(request: CreateCampaign): HttpRequest =
     Post(apiUri("campaigns"), request).withHeaders(header)
 
-  def createRetryCampaign(mainCampaignId: CampaignId, request: RetryFailedDevices): HttpRequest =
+  def createAndLaunchRetryCampaign(mainCampaignId: CampaignId, request: RetryFailedDevices): HttpRequest =
     Post(apiUri(s"campaigns/${mainCampaignId.show}/retry-failed"), request).withHeaders(header)
 
   def createCampaignOk(request: CreateCampaign): CampaignId =
     createCampaign(request) ~> routes ~> check {
+      status shouldBe Created
+      responseAs[CampaignId]
+    }
+
+  def createAndLaunchRetryCampaignOk(mainCampaignId: CampaignId, request: RetryFailedDevices): CampaignId =
+    createAndLaunchRetryCampaign(mainCampaignId, request) ~> routes ~> check {
       status shouldBe Created
       responseAs[CampaignId]
     }


### PR DESCRIPTION
Supersedes #100.

- Add a new endpoint to create and launch a new retry-campaign given a failure code.
- Store the failure code when creating the retry-campaign. We need that so that the FE can show the status of the retry-campaigns in the UI.