### PR TITLE
[OTA-2308] Create endpoint to export campaign installation failures as CSV

### DIFF
--- a/src/main/resources/db/migration/V16__add_result_description_to_device_update.sql
+++ b/src/main/resources/db/migration/V16__add_result_description_to_device_update.sql
@@ -1,0 +1,1 @@
+ALTER TABLE device_updates ADD COLUMN result_description VARCHAR(255) NULL;

--- a/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/Codecs.scala
@@ -12,7 +12,6 @@ object Codecs {
   import DataType.RetryStatus.RetryStatus
   import io.circe.generic.semiauto._
 
-
   implicit val createCampaignMetadataEncoder: Encoder[CreateCampaignMetadata] = deriveEncoder
   implicit val createCampaignMetadataDecoder: Decoder[CreateCampaignMetadata] = deriveDecoder
 

--- a/src/main/scala/com/advancedtelematic/campaigner/data/CsvSerializer.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/CsvSerializer.scala
@@ -1,0 +1,27 @@
+package com.advancedtelematic.campaigner.data
+
+import cats.Show
+import cats.syntax.show._
+
+trait CsvSerializer[T] {
+  def toCsvRow(value: T): Seq[String]
+}
+
+object CsvSerializer {
+  val fieldSeparator = ";"
+  val recordSeparator = "\n"
+
+  implicit val showString: Show[String] = identity _
+
+  implicit def tuple3Serializer[A: Show, B: Show, C: Show]: CsvSerializer[(A, B, C)] =
+    (t: (A, B, C)) => t._1.show +: t._2.show +: t._3.show +: Nil
+
+  implicit val deviceIdFailureSerializer = implicitly[CsvSerializer[(String, String, String)]]
+
+  def asCsv[T](header: Seq[String], rows: Seq[T])(implicit serializer: CsvSerializer[T]): String = {
+    val head = header.mkString(fieldSeparator)
+    val body = rows.map(serializer.toCsvRow(_).mkString(fieldSeparator))
+    (head +: body).mkString(recordSeparator)
+  }
+}
+

--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -147,6 +147,7 @@ object DataType {
     device: DeviceId,
     status: DeviceStatus,
     resultCode: Option[String] = None,
+    resultDescription: Option[String] = None,
     updatedAt: Instant = Instant.now
   )
 

--- a/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
@@ -70,7 +70,7 @@ class DeviceUpdateProcess(director: DirectorClient)(implicit db: Database, ec: E
           _logger.warn(s"Could not start mtu update for device $deviceId after device accepted, device is no longer affected")
 
           campaigns.scheduleDevices(campaignId, campaign.update, deviceId).flatMap { _ =>
-            campaigns.failDevice(campaign.update, deviceId, "failure-code-1")
+            campaigns.failDevice(campaign.update, deviceId, "DEVICE_UPDATE_PROCESS_FAILED", "DeviceUpdateProcess#processDeviceAcceptedUpdate failed")
           }
       }
     } yield ()

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
@@ -102,23 +102,23 @@ protected [db] class DeviceUpdateRepository()(implicit db: Database, ec: Executi
       .map(_.toSet)
   }
 
-  protected [db] def setUpdateStatusAction(update: UpdateId, device: DeviceId, status: DeviceStatus, resultCode: Option[String]): DBIO[Unit] =
+  protected [db] def setUpdateStatusAction(update: UpdateId, device: DeviceId, status: DeviceStatus, resultCode: Option[String], resultDescription: Option[String]): DBIO[Unit] =
     Schema.deviceUpdates
       .filter(_.updateId === update)
       .filter(_.deviceId === device)
-      .map(du => (du.status, du.resultCode))
-      .update((status, resultCode))
+      .map(du => (du.status, du.resultCode, du.resultDescription))
+      .update((status, resultCode, resultDescription))
       .flatMap {
         case 0 => DBIO.failed(DeviceNotScheduled)
         case _ => DBIO.successful(())
       }.map(_ => ())
 
-  protected [db] def setUpdateStatusAction(campaign: CampaignId, devices: Seq[DeviceId], status: DeviceStatus, resultCode: Option[String]): DBIO[Unit] =
+  protected [db] def setUpdateStatusAction(campaign: CampaignId, devices: Seq[DeviceId], status: DeviceStatus, resultCode: Option[String], resultDescription: Option[String]): DBIO[Unit] =
     Schema.deviceUpdates
       .filter(_.campaignId === campaign)
       .filter(_.deviceId inSet devices)
-      .map(du => (du.status, du.resultCode))
-      .update((status, resultCode))
+      .map(du => (du.status, du.resultCode, du.resultDescription))
+      .update((status, resultCode, resultDescription))
       .flatMap {
         case n if devices.length == n => DBIO.successful(())
         case _ => DBIO.failed(DeviceNotScheduled)

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Schema.scala
@@ -72,11 +72,12 @@ object Schema {
     def deviceId   = column[DeviceId]("device_id")
     def status     = column[DeviceStatus]("status")
     def resultCode = column[Option[String]]("result_code")
+    def resultDescription = column[Option[String]]("result_description")
     def updatedAt  = column[Instant]("updated_at")
 
     def pk = primaryKey("device_updates_pk", (campaignId, deviceId))
 
-    override def * = (campaignId, updateId, deviceId, status, resultCode, updatedAt) <>
+    override def * = (campaignId, updateId, deviceId, status, resultCode, resultDescription, updatedAt) <>
                      ((DeviceUpdate.apply _).tupled, DeviceUpdate.unapply)
   }
 

--- a/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
@@ -1,6 +1,8 @@
 package com.advancedtelematic.campaigner.http
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.marshalling.{Marshaller, ToResponseMarshaller}
+import akka.http.scaladsl.model.headers.{ContentDispositionTypes, `Content-Disposition`}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.{Directive1, Route}
 import akka.http.scaladsl.server.Directives._
 import cats.data.NonEmptyList
@@ -8,6 +10,7 @@ import com.advancedtelematic.campaigner.Settings
 import com.advancedtelematic.campaigner.client.{DeviceRegistryClient, DirectorClient}
 import com.advancedtelematic.campaigner.data.AkkaSupport._
 import com.advancedtelematic.campaigner.data.Codecs._
+import com.advancedtelematic.campaigner.data.CsvSerializer
 import com.advancedtelematic.campaigner.data.DataType.CampaignStatus.CampaignStatus
 import com.advancedtelematic.campaigner.data.DataType.SortBy.SortBy
 import com.advancedtelematic.campaigner.data.DataType._
@@ -43,6 +46,31 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope],
     */
   def retryFailedDevices(ns: Namespace, mainCampaign: Campaign, request: RetryFailedDevices): Future[CampaignId] =
     campaigns.retryCampaign(ns, mainCampaign, request.failureCode)
+
+
+  implicit val installationFailureCsvMarshaller: ToResponseMarshaller[Seq[(String, String, String)]] =
+    Marshaller.withFixedContentType(ContentTypes.`text/csv(UTF-8)`) { t =>
+      val csv = CsvSerializer.asCsv(Seq("Device ID", "Failure Code", "Failure Description"), t)
+      val e = HttpEntity(ContentTypes.`text/csv(UTF-8)`, csv)
+      val h = `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "device-failures.csv"))
+      HttpResponse(headers = h :: Nil, entity = e)
+    }
+
+
+  /**
+    * For the devices that are in failed status `failureCode` after executing the campaign with ID `campaignId`
+    * or any of its retry-campaigns, calculate the triplets (DeviceOemId, ResultCode, ResultDescription) and
+    * return them as a CSV file.
+    */
+  def fetchFailureCodes(ns: Namespace, campaignId: CampaignId, failureCode: String): Route = {
+    val f = campaigns.fetchFailureCodes(campaignId, failureCode).flatMap {
+      Future.traverse(_) { case (did, fc, fd) =>
+        deviceRegistry.fetchOemId(ns, did).map((_, fc, fd))
+      }
+      .map(_.toSeq)
+    }
+    complete(f)
+  }
 
   private def UserCampaignPathPrefix(namespace: Namespace): Directive1[Campaign] =
     pathPrefix(CampaignId.Path).flatMap { campaign =>
@@ -90,8 +118,13 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope],
               complete(StatusCodes.Created -> retryFailedDevices(ns, campaign, request))
             }
           } ~
-          (get & path("stats")) {
-            complete(campaigns.campaignStats(campaign.id))
+          get {
+            path("stats") {
+              complete(campaigns.campaignStats(campaign.id))
+            } ~
+            (path("failed-installations.csv") & parameter('failureCode.as[String])) {
+              failureCode => fetchFailureCodes(ns, campaign.id, failureCode)
+            }
           }
         }
       } ~

--- a/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/CampaignResource.scala
@@ -48,14 +48,13 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope],
     campaigns.retryCampaign(ns, mainCampaign, request.failureCode)
 
 
-  implicit val installationFailureCsvMarshaller: ToResponseMarshaller[Seq[(String, String, String)]] =
+  def installationFailureCsvMarshaller(campaignId: CampaignId): ToResponseMarshaller[Seq[(String, String, String)]] =
     Marshaller.withFixedContentType(ContentTypes.`text/csv(UTF-8)`) { t =>
       val csv = CsvSerializer.asCsv(Seq("Device ID", "Failure Code", "Failure Description"), t)
       val e = HttpEntity(ContentTypes.`text/csv(UTF-8)`, csv)
-      val h = `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> "device-failures.csv"))
+      val h = `Content-Disposition`(ContentDispositionTypes.attachment, Map("filename" -> s"campaign-${campaignId.uuid.toString}-device-failures.csv"))
       HttpResponse(headers = h :: Nil, entity = e)
     }
-
 
   /**
     * For the devices that are in failed status `failureCode` after executing the campaign with ID `campaignId`
@@ -69,6 +68,7 @@ class CampaignResource(extractAuth: Directive1[AuthedNamespaceScope],
       }
       .map(_.toSeq)
     }
+    implicit val marshaller = installationFailureCsvMarshaller(campaignId)
     complete(f)
   }
 

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -70,14 +70,17 @@ object Generators {
 
   def genDeviceUpdate(
       genCampaignId: Gen[CampaignId] = arbitrary[CampaignId],
-      genResultCode: Gen[String] = Gen.alphaNumStr): Gen[DeviceUpdate] = for {
-    cid <- genCampaignId
-    uid <- genUpdateId
-    did <- genDeviceId
-    st <- Gen.oneOf(DeviceStatus.values.toSeq)
-    rc <- Gen.option(genResultCode)
-    upAt <- Gen.posNum[Long].map(Instant.ofEpochSecond)
-  } yield DeviceUpdate(cid, uid, did, st, rc, upAt)
+      genResultCode: Gen[String] = Gen.alphaNumStr,
+      genResultDescription: Gen[String] = Gen.alphaNumStr): Gen[DeviceUpdate] =
+    for {
+      cid <- genCampaignId
+      uid <- genUpdateId
+      did <- genDeviceId
+      st <- Gen.oneOf(DeviceStatus.values.toSeq)
+      rc <- Gen.option(genResultCode)
+      rd <- Gen.option(genResultDescription)
+      upAt <- Gen.posNum[Long].map(Instant.ofEpochSecond)
+    } yield DeviceUpdate(cid, uid, did, st, rc, rd, upAt)
 
   implicit lazy val arbCampaignId: Arbitrary[CampaignId] = Arbitrary(genCampaignId)
   implicit lazy val arbGroupId: Arbitrary[GroupId] = Arbitrary(genGroupId)

--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -82,6 +82,13 @@ object Generators {
       upAt <- Gen.posNum[Long].map(Instant.ofEpochSecond)
     } yield DeviceUpdate(cid, uid, did, st, rc, rd, upAt)
 
+  val genExportCase: Gen[(DeviceId, String, String, String)] = for {
+    deviceId <- genDeviceId
+    deviceOemId <- Gen.alphaNumStr.map("OEM-ID-" + _)
+    failureCode <- Gen.alphaStr.map("FAILURE-CODE-" + _)
+    failureDescription <- Gen.alphaStr.map("FAILURE-DESCRIPTION-" + _)
+  } yield (deviceId, deviceOemId, failureCode, failureDescription)
+
   implicit lazy val arbCampaignId: Arbitrary[CampaignId] = Arbitrary(genCampaignId)
   implicit lazy val arbGroupId: Arbitrary[GroupId] = Arbitrary(genGroupId)
   implicit lazy val arbDeviceId: Arbitrary[DeviceId] = Arbitrary(genDeviceId)
@@ -95,4 +102,5 @@ object Generators {
   implicit lazy val arbMetadataType: Arbitrary[MetadataType] = Arbitrary(genMetadataType)
   implicit lazy val arbCreateUpdate: Arbitrary[CreateUpdate] = Arbitrary(genCreateUpdate())
   implicit lazy val arbNonEmptyGroupIdList: Arbitrary[NonEmptyList[GroupId]] = Arbitrary(genNonEmptyGroupIdList)
+
 }

--- a/src/test/scala/com/advancedtelematic/campaigner/db/CampaignsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/db/CampaignsSpec.scala
@@ -49,7 +49,7 @@ class CampaignsSpec extends AsyncFlatSpec
       update <- createDbUpdate(UpdateId.generate())
       newCampaigns <- FastFuture.traverse(arbitrary[Seq[Int]].generate)(_ => createDbCampaign(ns, update, group))
       _ <- FastFuture.traverse(newCampaigns)(c => campaigns.scheduleDevices(c.id, update, device))
-      _ <- campaigns.succeedDevice(update, device, "success-code-1")
+      _ <- campaigns.succeedDevice(update, device, "success-code-1", "success-description-1")
       stats <- campaigns.campaignStats(newCampaigns.head.id)
     } yield stats.finished shouldBe 1
   }
@@ -60,7 +60,7 @@ class CampaignsSpec extends AsyncFlatSpec
     for {
       campaign <- createDbCampaignWithUpdate()
       _ <- FastFuture.traverse(devices)(d => campaigns.scheduleDevices(campaign.id, campaign.updateId, d))
-      _ <- FastFuture.traverse(devices)(d => campaigns.failDevice(campaign.updateId, d, "failure-code-1"))
+      _ <- FastFuture.traverse(devices)(d => campaigns.failDevice(campaign.updateId, d, "failure-code-1", "failure-description-1"))
       stats <- campaigns.campaignStats(campaign.id)
     } yield stats.finished shouldBe devices.length
   }

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -2,7 +2,9 @@ package com.advancedtelematic.campaigner.http
 
 import java.time.temporal.ChronoUnit
 
+import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.StatusCodes._
+import akka.util.ByteString
 import cats.data.NonEmptyList
 import cats.syntax.either._
 import cats.syntax.option._
@@ -27,6 +29,7 @@ import org.scalactic.source
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
 
+import scala.annotation.tailrec
 import scala.concurrent.Future
 
 class CampaignResourceSpec
@@ -314,6 +317,47 @@ class CampaignResourceSpec
       resultNames.size shouldBe expected.size
       resultNames should contain allElementsOf expected
     }
+  }
+
+  "GET /campaigns/:id/failed-installations.csv" should "export the failed installations in a CSV" in {
+
+    def assertCsvResponse(expected: Seq[String]): Unit = {
+      status shouldBe OK
+      contentType shouldBe ContentTypes.`text/csv(UTF-8)`
+      val result = entityAs[ByteString].utf8String.split("\n")
+      result.tail should contain allElementsOf expected
+    }
+
+    @tailrec
+    def failInstallationsAndCheckExport(campaignId: CampaignId, testCase: Seq[(DeviceId, String, String, String)]): Unit = testCase match {
+      case Nil => ()
+
+      case succeeded :: failedHead :: failedTail =>
+        val failed = failedHead :: failedTail
+        campaigns
+          .succeedDevices(campaignId, succeeded._1 :: Nil, "SUCCESS", "EUREKA")
+          .flatMap(_ => campaigns.failDevices(campaignId, failed.map(_._1), failedHead._3, failedHead._4))
+          .futureValue
+
+        getFailedExport(campaignId, failedHead._3) ~> routes ~> check {
+          val expected = failed.map(_._2).tail.map(oemId => s"$oemId;${failedHead._3};${failedHead._4}")
+          assertCsvResponse(expected)
+        }
+
+        failInstallationsAndCheckExport(campaignId, failed)
+
+      case succeeded :: _ =>
+        campaigns.succeedDevices(campaignId, succeeded._1 :: Nil, "SUCCESS", "EUREKA").futureValue
+    }
+
+    val testCase = Gen.listOfN(20, genExportCase).generate
+    val (campaignId, _) = createCampaignWithUpdateOk()
+    val campaign = campaigns.findNamespaceCampaign(testNs, campaignId).futureValue
+
+    fakeRegistry.setOemIds(testCase.map(_._1).zip(testCase.map(_._2)): _*)
+    campaigns.scheduleDevices(campaignId, campaign.updateId, testCase.map(_._1): _*).futureValue
+
+    failInstallationsAndCheckExport(campaignId, testCase)
   }
 
   "GET /campaigns/:id/stats" should "return correct statistics" in {

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -140,11 +140,11 @@ class CampaignResourceSpec
   "POST /campaigns/:campaign_id/retry-failed" should "create and launch a retry-campaign" in {
     val (mainCampaignId, mainCampaign) = createCampaignWithUpdateOk()
     val deviceId = genDeviceId.generate
-    val failureCode = "failureCode-1"
+    val (failureCode, failureDescription) = ("failure-code-1", "failure-description-1")
     val deviceUpdate = DeviceUpdate(mainCampaignId, mainCampaign.update, deviceId, DeviceStatus.accepted, Some(failureCode))
 
     deviceUpdateRepo.persistMany(deviceUpdate :: Nil).futureValue
-    campaigns.failDevices(mainCampaignId, deviceId :: Nil, failureCode).futureValue
+    campaigns.failDevices(mainCampaignId, deviceId :: Nil, failureCode, failureDescription).futureValue
 
     val retryCampaignId = createAndLaunchRetryCampaign(mainCampaignId, RetryFailedDevices(failureCode)) ~> routes ~> check {
       status shouldBe Created
@@ -346,8 +346,8 @@ class CampaignResourceSpec
       _ <- campaigns.scheduleDevices(campaignId, updateId, campaignCase.affectedDevices:_*)
       _ <- campaigns.rejectDevices(campaignId, updateId, campaignCase.notAffectedDevices)
       _ <- campaigns.cancelDevices(campaignId, campaignCase.cancelledDevices)
-      _ <- campaigns.failDevices(campaignId, campaignCase.failedDevices, failureCode)
-      _ <- campaigns.succeedDevices(campaignId, campaignCase.successfulDevices, "success-code-1")
+      _ <- campaigns.failDevices(campaignId, campaignCase.failedDevices, failureCode, "failure-description-1")
+      _ <- campaigns.succeedDevices(campaignId, campaignCase.successfulDevices, "success-code-1", "success-description-1")
     } yield ()
 
     forAll(genCampaignCase) { mainCase =>

--- a/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/util/ResourceSpec.scala
@@ -1,9 +1,9 @@
 package com.advancedtelematic.campaigner.util
 
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.{HttpRequest, Uri}
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{HttpRequest, Uri}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import cats.syntax.show._
@@ -14,6 +14,7 @@ import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.http.Routes
 import com.advancedtelematic.libats.data.DataType.Namespace
 import com.advancedtelematic.libats.data.PaginationResult
+import com.advancedtelematic.libats.http.HttpOps._
 import com.advancedtelematic.libats.test.DatabaseSpec
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import io.circe.Json
@@ -78,6 +79,11 @@ trait ResourceSpec extends ScalatestRouteTest
       status shouldBe OK
       responseAs[PaginationResult[CampaignId]]
     }
+  }
+
+  def getFailedExport(campaignId: CampaignId, failureCode: String): HttpRequest = {
+    val q = Query("failureCode" -> failureCode)
+    Get(apiUri(s"campaigns/${campaignId.show}/failed-installations.csv").withQuery(q)).withNs(testNs)
   }
 }
 


### PR DESCRIPTION
Based on #110. Only the last two commits are new here.

Arguably we want to move the export endpoint to campaigner. For that we're asking device-registry for the `oemId`s of the devices. But we don't store them, just put them in the CSV and forget about them.
If we move on with this, shortly after I'll remove the current export endpoint from device-registry.