### PR TITLE
Fix flaky tests due to UpdateSource id conflicts

### DIFF
--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -48,7 +48,7 @@ object Generators {
   } yield UpdateCampaign(n, Option(List(meta)))
 
   def genUpdateSource(genType: => Gen[UpdateType]): Gen[UpdateSource] = for {
-    id <- arbitrary[String].suchThat(_.length < 200)
+    id <- arbitrary[String].retryUntil(_.length > 0)
     t <- genType
   } yield UpdateSource(ExternalUpdateId(id), t)
 


### PR DESCRIPTION
Some tests are flaky because there is a 409 conflict error if the generators repeat an `UpdateSource` with `id=""`.