### PR TITLE
[OTA-2479] Fix calculation of retry-campaigns status

### DIFF
--- a/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/data/Generators.scala
@@ -76,7 +76,15 @@ object Generators {
       cid <- genCampaignId
       uid <- genUpdateId
       did <- genDeviceId
-      st <- Gen.oneOf(DeviceStatus.values.toSeq)
+      st <- Gen.frequency(
+        1 -> DeviceStatus.accepted,
+        1 -> DeviceStatus.scheduled,
+        1 -> DeviceStatus.requested,
+        1 -> DeviceStatus.rejected,
+        1 -> DeviceStatus.cancelled,
+        1 -> DeviceStatus.successful,
+        3 -> DeviceStatus.failed
+      )
       rc <- Gen.option(genResultCode)
       rd <- Gen.option(genResultDescription)
       upAt <- Gen.posNum[Long].map(Instant.ofEpochSecond)


### PR DESCRIPTION
There is a bug in the calculation of the last `DeviceUpdate` that failed. We are finding the last update and checking if it was a failure. What we actually want is the last update that _finished_ with a failure, i.e. the last update with `status = failed` and with `status not in (requested, scheduled, accepted)`.
Otherwise if the device is e.g. in `accepted` status in a retry-campaign we won't find the last failure, because the latest status is `accepted`.