### PR TITLE
Fix launching retry-campaign when a device fails with a new code

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -67,14 +67,15 @@ object DataType {
                                   approvalNeeded: Option[Boolean] = Some(false))
   {
     def mkCampaign(ns: Namespace): Campaign = {
+      val now = Instant.now
       Campaign(
         ns,
         CampaignId.generate(),
         name,
         update,
         CampaignStatus.prepared,
-        Instant.now(),
-        Instant.now(),
+        now,
+        now,
         None,
         None,
         !approvalNeeded.getOrElse(false)

--- a/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
@@ -62,7 +62,7 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
     listener.apply(report).futureValue shouldBe (())
     deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.failed).futureValue should contain(deviceUpdate.device)
-    campaigns.fetchFailedDevices(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
+    campaigns.findLatestFailedUpdates(campaign.id, "FAILURE").map(_.map(_.device)).futureValue should contain(deviceUpdate.device)
   }
 
   "Listener" should "mark a device as failed using campaign CorrelationId" in {
@@ -75,7 +75,7 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
     listener.apply(report).futureValue shouldBe (())
     deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.failed).futureValue should contain(deviceUpdate.device)
-    campaigns.fetchFailedDevices(campaign.id, "FAILURE").futureValue should contain(deviceUpdate.device)
+    campaigns.findLatestFailedUpdates(campaign.id, "FAILURE").map(_.map(_.device)).futureValue should contain(deviceUpdate.device)
   }
 
   "Listener" should "mark a device as canceled using campaign CorrelationId" in {


### PR DESCRIPTION
Currently, if a device fails in a retry-campaign with a failure code that is different than the one it originally failed with, we are not able to take it into account when launching a new retry-campaign for the new failure code. Instead we get a `MissingFailedDevices` error because we're only searching for devices that failed under the main campaign. This commit fixes that and adds a test for it.