### PR TITLE
[OTA-2377] Remove the groups from the GET campaign endpoint

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/data/DataType.scala
@@ -98,14 +98,12 @@ object DataType {
     updatedAt: Instant,
     mainCampaignId: Option[CampaignId],
     retryCampaignIds: Set[CampaignId],
-    // TODO (OTA-2377) remove the field when FE is not dependent on it anymore
-    groups: Set[GroupId],
     metadata: Seq[CreateCampaignMetadata],
     autoAccept: Boolean
   )
 
   object GetCampaign {
-    def apply(c: Campaign, retryCampaignIds: Set[CampaignId], groups: Set[GroupId], metadata: Seq[CampaignMetadata]): GetCampaign =
+    def apply(c: Campaign, retryCampaignIds: Set[CampaignId], metadata: Seq[CampaignMetadata]): GetCampaign =
       GetCampaign(
         c.namespace,
         c.id,
@@ -116,7 +114,6 @@ object DataType {
         c.updatedAt,
         c.mainCampaignId,
         retryCampaignIds,
-        groups,
         metadata.map(m => CreateCampaignMetadata(m.`type`, m.value)),
         c.autoAccept
       )

--- a/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/CampaignResourceSpec.scala
@@ -76,7 +76,6 @@ class CampaignResourceSpec
       campaign.updatedAt,
       None,
       Set.empty,
-      request.groups.toList.toSet,
       request.metadata.toList.flatten,
       autoAccept = true
     )
@@ -103,7 +102,6 @@ class CampaignResourceSpec
       campaign.updatedAt,
       None,
       Set.empty,
-      request.groups.toList.toSet,
       request.metadata.toList.flatten,
       autoAccept = true
     )
@@ -497,7 +495,6 @@ class CampaignResourceSpec
         retryCampaign.createdAt,
         retryCampaign.updatedAt,
         Some(mainCampaignId),
-        Set.empty,
         Set.empty,
         Nil,
         autoAccept = true


### PR DESCRIPTION
The groups were needed for the calculation of the stats in the FE. Since we have refactored the stats endpoint they're no longer needed.