### PR TITLE
Do not handle device update events with MTU correlation ID

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
@@ -70,7 +70,7 @@ class DeviceUpdateProcess(director: DirectorClient)(implicit db: Database, ec: E
           _logger.warn(s"Could not start mtu update for device $deviceId after device accepted, device is no longer affected")
 
           campaigns.scheduleDevices(campaignId, campaign.update, deviceId).flatMap { _ =>
-            campaigns.failDevice(campaign.update, deviceId, ResultCode("DEVICE_UPDATE_PROCESS_FAILED"), ResultDescription("DeviceUpdateProcess#processDeviceAcceptedUpdate failed"))
+            campaigns.failDevices(campaignId, Seq(deviceId), ResultCode("DEVICE_UPDATE_PROCESS_FAILED"), ResultDescription("DeviceUpdateProcess#processDeviceAcceptedUpdate failed"))
           }
       }
     } yield ()

--- a/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/DeviceUpdateProcess.scala
@@ -65,11 +65,11 @@ class DeviceUpdateProcess(director: DirectorClient)(implicit db: Database, ec: E
       affected <- director.setMultiUpdateTarget(ns, update.source.id, Seq(deviceId), CampaignCorrelationId(campaignId.uuid))
       _ <- affected.find(_ == deviceId) match {
         case Some(_) =>
-          campaigns.markDevicesAccepted(campaignId, campaign.update, deviceId)
+          campaigns.markDevicesAccepted(campaignId, Seq(deviceId))
         case None =>
           _logger.warn(s"Could not start mtu update for device $deviceId after device accepted, device is no longer affected")
 
-          campaigns.scheduleDevices(campaignId, campaign.update, deviceId).flatMap { _ =>
+          campaigns.scheduleDevices(campaignId, Seq(deviceId)).flatMap { _ =>
             campaigns.failDevices(campaignId, Seq(deviceId), ResultCode("DEVICE_UPDATE_PROCESS_FAILED"), ResultDescription("DeviceUpdateProcess#processDeviceAcceptedUpdate failed"))
           }
       }

--- a/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/Repository.scala
@@ -103,17 +103,6 @@ protected [db] class DeviceUpdateRepository()(implicit db: Database, ec: Executi
       .map(_.toSet)
   }
 
-  protected [db] def setUpdateStatusAction(update: UpdateId, device: DeviceId, status: DeviceStatus, resultCode: Option[ResultCode], resultDescription: Option[ResultDescription]): DBIO[Unit] =
-    Schema.deviceUpdates
-      .filter(_.updateId === update)
-      .filter(_.deviceId === device)
-      .map(du => (du.status, du.resultCode, du.resultDescription))
-      .update((status, resultCode, resultDescription))
-      .flatMap {
-        case 0 => DBIO.failed(DeviceNotScheduled)
-        case _ => DBIO.successful(())
-      }.map(_ => ())
-
   protected [db] def setUpdateStatusAction(campaign: CampaignId, devices: Seq[DeviceId], status: DeviceStatus, resultCode: Option[ResultCode], resultDescription: Option[ResultDescription]): DBIO[Unit] =
     Schema.deviceUpdates
       .filter(_.campaignId === campaign)

--- a/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/actor/CampaignSupervisorSpec.scala
@@ -38,8 +38,7 @@ class CampaignSupervisorSpec extends ActorSpec[CampaignSupervisor] with Campaign
       Seq.empty).futureValue
     campaigns.scheduleDevices(
       scheduledCampaign.id,
-      scheduledCampaign.updateId,
-      scheduledCampaignDevices.toSeq:_*).futureValue
+      scheduledCampaignDevices.toSeq).futureValue
 
     val partiallyScheduledCampaignDevices = Gen.listOfN(n, genDeviceId).generate.toSet
     val nScheduled = Gen.choose(1, n - 1).generate
@@ -50,8 +49,7 @@ class CampaignSupervisorSpec extends ActorSpec[CampaignSupervisor] with Campaign
       Seq.empty).futureValue
     campaigns.scheduleDevices(
       partiallyScheduledCampaign.id,
-      partiallyScheduledCampaign.updateId,
-      partiallyScheduledCampaignDevices.take(nScheduled).toSeq:_*).futureValue
+      partiallyScheduledCampaignDevices.take(nScheduled).toSeq).futureValue
 
     parent.childActorOf(CampaignSupervisor.props(
       director,

--- a/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/daemon/DeviceUpdateEventListenerSpec.scala
@@ -7,7 +7,7 @@ import com.advancedtelematic.campaigner.data.DataType._
 import com.advancedtelematic.campaigner.data.Generators._
 import com.advancedtelematic.campaigner.db.{Campaigns, DeviceUpdateSupport, UpdateSupport}
 import com.advancedtelematic.campaigner.util.{CampaignerSpec, DatabaseUpdateSpecUtil}
-import com.advancedtelematic.libats.data.DataType.{CorrelationId, MultiTargetUpdateId, ResultCode, ResultDescription, CampaignId => CampaignCorrelationId}
+import com.advancedtelematic.libats.data.DataType.{CorrelationId, ResultCode, ResultDescription, CampaignId => CampaignCorrelationId}
 import com.advancedtelematic.libats.messaging_datatype.DataType.{DeviceId, InstallationResult}
 import com.advancedtelematic.libats.messaging_datatype.Messages.{DeviceUpdateCanceled, DeviceUpdateCompleted, DeviceUpdateEvent}
 import com.advancedtelematic.libats.test.DatabaseSpec
@@ -25,18 +25,6 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
   val campaigns = Campaigns()
 
-  "Listener" should "mark a device as successful using external update id" in {
-    val (updateSource, campaign, deviceUpdate) = prepareTest()
-    val report = makeReport(
-      campaign,
-      deviceUpdate,
-      MultiTargetUpdateId(UUID.fromString(updateSource.id.value)),
-      isSuccessful = true)
-
-    listener.apply(report).futureValue shouldBe (())
-    deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.successful).futureValue should contain(deviceUpdate.device)
-  }
-
   "Listener" should "mark a device as successful using campaign CorrelationId" in {
     val (_, campaign, deviceUpdate) = prepareTest()
     val report = makeReport(
@@ -47,19 +35,6 @@ class DeviceUpdateEventListenerSpec extends CampaignerSpec
 
     listener.apply(report).futureValue shouldBe (())
     deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.successful).futureValue should contain(deviceUpdate.device)
-  }
-
-  "Listener" should "mark a device as failed using external update id" in {
-    val (updateSource, campaign, deviceUpdate) = prepareTest()
-    val report = makeReport(
-      campaign,
-      deviceUpdate,
-      MultiTargetUpdateId(UUID.fromString(updateSource.id.value)),
-      isSuccessful = false)
-
-    listener.apply(report).futureValue shouldBe (())
-    deviceUpdateRepo.findByCampaign(campaign.id, DeviceStatus.failed).futureValue should contain(deviceUpdate.device)
-    campaigns.findLatestFailedUpdates(campaign.id, ResultCode("FAILURE")).map(_.map(_.device)).futureValue should contain(deviceUpdate.device)
   }
 
   "Listener" should "mark a device as failed using campaign CorrelationId" in {

--- a/src/test/scala/com/advancedtelematic/campaigner/db/CampaignsSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/db/CampaignsSpec.scala
@@ -42,7 +42,7 @@ class CampaignsSpec extends AsyncFlatSpec
 
     for {
       campaign <- createDbCampaignWithUpdate()
-      _ <- campaigns.scheduleDevices(campaign.id, campaign.updateId, devices:_*)
+      _ <- campaigns.scheduleDevices(campaign.id, devices)
       _ <- campaigns.failDevices(campaign.id, devices, ResultCode("failure-code-1"), ResultDescription("failure-description-1"))
       stats <- campaigns.campaignStats(campaign.id)
     } yield stats.finished shouldBe devices.length

--- a/src/test/scala/com/advancedtelematic/campaigner/http/DeviceResourceSpec.scala
+++ b/src/test/scala/com/advancedtelematic/campaigner/http/DeviceResourceSpec.scala
@@ -21,7 +21,7 @@ class DeviceResourceSpec
     val (campaignId,request) = createCampaignWithUpdateOk(arbitrary[CreateCampaign].retryUntil(_.metadata.nonEmpty))
     val device = DeviceId.generate()
 
-    campaigns.scheduleDevices(campaignId, request.update, device).futureValue
+    campaigns.scheduleDevices(campaignId, Seq(device)).futureValue
 
     Get(apiUri(s"device/${device.uuid}/campaigns")).withHeaders(header) ~> routes ~> check {
       status shouldBe StatusCodes.OK


### PR DESCRIPTION
MTU are not related to campaigns, and thus should not be used to change
the state of campaign devices, especially not in _all_ the campaigns.
According to @jerrytrieu, this "overly backward compatible" thing was
implemented to because
 
> Before correlation ids devices in campaigns had mtuid only, So some devices may complete a campaign long after it started. This was to handle that case

and should be safe to remove now.