### PR TITLE
[OTA-2661] Do not update the status of a campaign if it was cancelled

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/db/CampaignStatusRecalculate.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/db/CampaignStatusRecalculate.scala
@@ -30,7 +30,7 @@ class CampaignStatusRecalculate()(implicit db: Database, ec: ExecutionContext, m
     Source.fromPublisher(source).mapAsyncUnordered(3) { campaignId =>
       db.run {
         statusTransition.calculateCampaignStatus(campaignId).map {
-          case Right(status) => status
+          case Some(status) => status
           case _ => CampaignStatus.launched
         }.flatMap { newStatus =>
           campaignRepo.setStatusAction(campaignId, newStatus).map(_ => newStatus)


### PR DESCRIPTION
Previously the status of a campaign was updated each time a new device
finishes. A campaign could get `cancelled` status when it had all its
groups cancelled. When switching from using groups to sets of
devices, this functionality was lost and a campaign could never get
`cancelled` status based on statuses of its devices.

This PR disables updating campaign's status when it's set as `cancelled`
by the code in `/api/v2/campaigns/<uuid>/cancel` endpoint.

NOTE: the status won't be changed to `failed` even if some cancelled
devices fail. Once it's cancelled, it won't EVER be changed. If this 
behaviour is not desirable, e.g. the campaign should get `failed` status
even though it was `cancelled` earlier, it could be fixed.