### PR TITLE
[OTA-2450] Device can cancel update from a campaign pending approval

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -19,6 +19,7 @@ object ErrorCodes {
   val DeviceNotScheduled = ErrorCode("device_not_scheduled")
   val ConflictingUpdate = ErrorCode("update_already_exists")
   val TimeoutFetchingUpdates = ErrorCode("timeout_fetching_updates")
+  val CampaignDoesNotRequireApproval = ErrorCode("campaign_does_not_require_approval")
 }
 
 object Errors {
@@ -77,4 +78,10 @@ object Errors {
     ErrorCodes.TimeoutFetchingUpdates,
     StatusCodes.GatewayTimeout,
     "It took too long to retrieve all the devices in the given groups.")
+
+  val UpdateNotCancellable = RawError(
+    ErrorCodes.CampaignDoesNotRequireApproval,
+    StatusCodes.MethodNotAllowed,
+    "This device update cannot be canceled because it does not come from a campaign that requires approval."
+  )
 }


### PR DESCRIPTION
Campaigner should only offer an endpoint to cancel updates for a device in a campaign that is pending approval, since these are not known to director yet, i.e. there is no assignment in director.

For the other cases, when an update has been assigned in director (a campaign update or a MTU) we should call director at `DELETE /api/v1/assignments/:deviceUuid` to cancel the update. Director will publish a `DeviceUpdateCancelled` event and, if the update came from a campaign, campaigner process the event and cancel the update.

**Note:** this comes with some changes in the FE to use the corresponding endpoints: https://github.com/advancedtelematic/ota-plus-server/pull/2034