### PR TITLE
[OTA-3153] Disallow creating campaigns without devices

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/http/Errors.scala
@@ -20,6 +20,7 @@ object ErrorCodes {
   val ConflictingUpdate = ErrorCode("update_already_exists")
   val TimeoutFetchingUpdates = ErrorCode("timeout_fetching_updates")
   val CampaignDoesNotRequireApproval = ErrorCode("campaign_does_not_require_approval")
+  val CampaignWithoutDevices = ErrorCode("campaign_without_devices")
 }
 
 object Errors {
@@ -83,5 +84,11 @@ object Errors {
     ErrorCodes.CampaignDoesNotRequireApproval,
     StatusCodes.MethodNotAllowed,
     "This device update cannot be canceled because it does not come from a campaign that requires approval."
+  )
+
+  val CampaignWithoutDevices = RawError(
+    ErrorCodes.CampaignWithoutDevices,
+    StatusCodes.BadRequest,
+    "None of the groups selected for the campaign contains any device."
   )
 }


### PR DESCRIPTION
Campaigns without devices (more precisely, with device groups without devices) are not finishing. This is because the campaign supervisor is simply not picking them up, since the logic to select the new campaigns only looks at the devices.
However, this use case shouldn't be allowed. So the changes in this PR are to disallow creating campaigns without devices (an error will be thrown if attempted).