### PR TITLE
Add gitlab CD integration for static code scans

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,9 @@ stages:
   - test
   - build image
   - trigger deploy
+  - veracode scan
+  - deps scan
+  - generate pages
 
 variables:
   MYSQL_ROOT_PASSWORD: "root"
@@ -79,3 +82,45 @@ trigger sit deploy:
   trigger:
     project: OLP/EDGE/OTA/infra/deployment-descriptors
     branch: master
+
+veracode scan:
+  # prepare and submit for static code analysis
+  stage: veracode scan
+  only:
+    variables:
+      - $VERACODE_API_ID
+  image: advancedtelematic/veracode:0.1.1
+  before_script:
+    - ./sbt package
+  script:
+    - run-veracode.sh
+  artifacts:
+    paths:
+      - /tmp/package.zip
+
+deps scan:
+  # perform dependencies CVE analysis
+  stage: deps scan
+  only:
+    - schedules
+  image: advancedtelematic/gitlab-jobs:0.2.0
+  script:
+    - ./sbt dependencyCheckAggregate
+    - mv target/scala-*/dependency-check-report.html ./depchk.html
+  artifacts:
+    paths:
+      - depchk.html
+
+pages:
+  stage: generate pages
+  only:
+    - schedules
+  dependencies:
+    - deps scan
+  script:
+    - mkdir -p public
+    - mv depchk.html public/index.html
+  artifacts:
+    paths:
+      - public
+    expire_in: 64 days


### PR DESCRIPTION
The veracode pipeline is intended to be run as part of schedule only.
