### PR TITLE
Support result descriptions bigger than 255 Chars

### DIFF
--- a/src/main/resources/db/migration/V17__increase_result_description_size.sql
+++ b/src/main/resources/db/migration/V17__increase_result_description_size.sql
@@ -1,0 +1,2 @@
+alter table `device_updates` MODIFY result_description VARCHAR(1024) NULL
+;


### PR DESCRIPTION
Increase the database column that saves the description to 1024 chars.

Cap incoming result descriptions that are bigger than 1024 chars and
save only the first part.

This assumes both the database and the jvm are using UTF-8 to transfer
the result description.

Signed-off-by: Simão Mata <simao.mata@here.com>