### PR TITLE
Skip processing errors on DeviceEventMessage

### DIFF
--- a/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
+++ b/src/main/scala/com/advancedtelematic/campaigner/DaemonBoot.scala
@@ -50,7 +50,7 @@ object DaemonBoot extends BootApp
   )
 
   startMonitoredListener[DeviceUpdateEvent](new DeviceUpdateEventListener)
-  startMonitoredListener[DeviceEventMessage](new DeviceEventListener(director))
+  startMonitoredListener[DeviceEventMessage](new DeviceEventListener(director), skipProcessingErrors = true)
 
   val routes: Route = (versionHeaders(version) & logResponseMetrics(projectName)) {
     prometheusMetricsRoutes ~


### PR DESCRIPTION
We should not keep this in as this prevents us from recovering from errors, but this feature is not working anyway and this is a quick fix for the production issue we have right now